### PR TITLE
Equip Spell Fixes

### DIFF
--- a/script/c1197847.lua
+++ b/script/c1197847.lua
@@ -1,0 +1,63 @@
+--幻煌龍の螺旋波
+--Spiral Wave of the Mythic Radiance Dragon
+--Script by nekrozar
+--fixed by MLD
+function c1197847.initial_effect(c)
+	aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsType,TYPE_NORMAL))
+	--indestructable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetCode(EFFECT_INDESTRUCTABLE_COUNT)
+	e3:SetCountLimit(1)
+	e3:SetValue(c1197847.valcon)
+	c:RegisterEffect(e3)
+	--spsummon
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(1197847,0))
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_HANDES)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCountLimit(1,1197847)
+	e4:SetCondition(c1197847.spcon)
+	e4:SetTarget(c1197847.sptg)
+	e4:SetOperation(c1197847.spop)
+	c:RegisterEffect(e4)
+end
+function c1197847.valcon(e,re,r,rp)
+	return bit.band(r,REASON_BATTLE)~=0
+end
+function c1197847.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipTarget()
+	return ec and ec:GetBattledGroupCount()>0
+end
+function c1197847.spfilter(c,e,tp)
+	return c:IsCode(56649609) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c1197847.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c1197847.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+	if Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0 then
+		Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,1-tp,1)
+	end
+end
+function c1197847.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c1197847.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		local tc=g:GetFirst()
+		if Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+			Duel.Equip(tp,c,tc)
+			Duel.SpecialSummonComplete()
+			if Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0 then
+				Duel.BreakEffect()
+				Duel.DiscardHand(1-tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)
+			end
+		end
+	end
+end

--- a/script/c18937875.lua
+++ b/script/c18937875.lua
@@ -13,13 +13,6 @@ function c18937875.initial_effect(c)
 	e3:SetCode(EFFECT_UPDATE_DEFENSE)
 	e3:SetValue(-200)
 	c:RegisterEffect(e3)
-	--equip limit
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_SINGLE)
-	e4:SetCode(EFFECT_EQUIP_LIMIT)
-	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e4:SetValue(c18937875.eqlimit)
-	c:RegisterEffect(e4)
 end
 function c18937875.filter(c)
 	return c:IsAttribute(ATTRIBUTE_FIRE)

--- a/script/c20436034.lua
+++ b/script/c20436034.lua
@@ -1,0 +1,53 @@
+--磁力の指輪
+function c20436034.initial_effect(c)
+	aux.AddEquipProcedure(c,0,nil,c20436034.eqlimit)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetTarget(c20436034.target)
+	e1:SetOperation(c20436034.operation)
+	c:RegisterEffect(e1)
+	--atk/def down
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(-500)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e3)
+	--
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_EQUIP)
+	e4:SetCode(EFFECT_ONLY_BE_ATTACKED)
+	c:RegisterEffect(e4)
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD)
+	e5:SetCode(EFFECT_ONLY_ATTACK_MONSTER)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetTargetRange(0,LOCATION_MZONE)
+	e5:SetCondition(c20436034.atkcon)
+	c:RegisterEffect(e5)
+end
+function c20436034.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c20436034.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
+		Duel.Equip(tp,e:GetHandler(),tc)
+	end
+end
+function c20436034.eqlimit(e,c)
+	return e:GetHandlerPlayer()==c:GetControler()
+end
+function c20436034.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetEquipTarget()~=nil
+end

--- a/script/c21702241.lua
+++ b/script/c21702241.lua
@@ -1,13 +1,6 @@
 --反目の従者
 function c21702241.initial_effect(c)
 	aux.AddEquipProcedure(c)
-	--Equip limit
-	local e2=Effect.CreateEffect(c)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_EQUIP_LIMIT)
-	e2:SetValue(1)
-	c:RegisterEffect(e2)
 	--damage
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(21702241,0))

--- a/script/c22147147.lua
+++ b/script/c22147147.lua
@@ -1,13 +1,6 @@
 --旋風剣
 function c22147147.initial_effect(c)
 	aux.AddEquipProcedure(c,nil,c22147147.filter)
-	--Equip limit
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_EQUIP_LIMIT)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetValue(c22147147.eqlimit)
-	c:RegisterEffect(e2)
 	--destroy
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(22147147,0))
@@ -40,7 +33,7 @@ end
 function c22147147.desop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) then
 		Duel.Destroy(tc,REASON_EFFECT)
 	end
 end

--- a/script/c23562407.lua
+++ b/script/c23562407.lua
@@ -1,0 +1,66 @@
+--聖剣カリバーン
+function c23562407.initial_effect(c)
+	c:SetUniqueOnField(1,0,23562407)
+	aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsRace,RACE_WARRIOR))
+	--Atk up
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(500)
+	c:RegisterEffect(e2)
+	--lp
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(23562407,0))
+	e4:SetCategory(CATEGORY_RECOVER)
+	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCountLimit(1)
+	e4:SetTarget(c23562407.lptg)
+	e4:SetOperation(c23562407.lpop)
+	c:RegisterEffect(e4)
+	--equip
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(23562407,1))
+	e5:SetCategory(CATEGORY_EQUIP)
+	e5:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e5:SetCode(EVENT_TO_GRAVE)
+	e5:SetCountLimit(1,23562407)
+	e5:SetCondition(c23562407.eqcon)
+	e5:SetTarget(c23562407.eqtg)
+	e5:SetOperation(c23562407.operation)
+	c:RegisterEffect(e5)
+end
+function c23562407.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and c:CheckUniqueOnField(tp) then
+		Duel.Equip(tp,c,tc)
+	end
+end
+function c23562407.lptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(500)
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,500)
+end
+function c23562407.lpop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Recover(p,d,REASON_EFFECT)
+end
+function c23562407.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousPosition(POS_FACEUP) and c:IsReason(REASON_DESTROY) and c:CheckUniqueOnField(tp)
+end
+function c23562407.eqfilter2(c)
+	return c:IsFaceup() and c:IsSetCard(0x107a) and c:IsRace(RACE_WARRIOR)
+end
+function c23562407.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c23562407.eqfilter2(chkc) end
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c23562407.eqfilter2,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c23562407.eqfilter2,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end

--- a/script/c303660.lua
+++ b/script/c303660.lua
@@ -1,0 +1,73 @@
+--電脳増幅器
+function c303660.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetTarget(c303660.target)
+	c:RegisterEffect(e1)
+	--Equip limit
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_EQUIP_LIMIT)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetValue(c303660.eqlimit)
+	c:RegisterEffect(e2)
+	--immune
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_IMMUNE_EFFECT)
+	e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetTargetRange(LOCATION_ONFIELD,LOCATION_ONFIELD)
+	e3:SetTarget(c303660.etarget)
+	e3:SetValue(c303660.efilter)
+	c:RegisterEffect(e3)
+	--leave
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e4:SetCode(EVENT_LEAVE_FIELD)
+	e4:SetOperation(c303660.desop)
+	c:RegisterEffect(e4)
+	--cannot disable
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetCode(EFFECT_CANNOT_DISABLE)
+	c:RegisterEffect(e5)
+end
+function c303660.eqlimit(e,c)
+	return c:IsCode(77585513)
+end
+function c303660.filter(c)
+	return c:IsFaceup() and c:IsCode(77585513)
+end
+function c303660.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c303660.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c303660.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c303660.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_CHAIN_SOLVING)
+	e1:SetReset(RESET_CHAIN)
+	e1:SetLabel(Duel.GetCurrentChain())
+	e1:SetLabelObject(e)
+	e1:SetOperation(aux.EquipEquip)
+	Duel.RegisterEffect(e1,tp)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c303660.etarget(e,c)
+	local ec=e:GetHandler():GetEquipTarget()
+	return c:IsType(TYPE_TRAP) and ec and c:GetControler()==ec:GetControler()
+end
+function c303660.efilter(e,re)
+	return re:GetHandler()==e:GetHandler():GetEquipTarget()
+end
+function c303660.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetHandler():GetFirstCardTarget()
+	if tc and tc:IsLocation(LOCATION_MZONE) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/script/c32437102.lua
+++ b/script/c32437102.lua
@@ -1,0 +1,22 @@
+--竜魂の力
+function c32437102.initial_effect(c)
+	aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsRace,RACE_WARRIOR),c32437102.eqlimit)
+	--Atk
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(500)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e3)
+	--race
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_EQUIP)
+	e4:SetCode(EFFECT_CHANGE_RACE)
+	e4:SetValue(RACE_DRAGON)
+	c:RegisterEffect(e4)
+end
+function c32437102.eqlimit(e,c)
+	return e:GetHandler():GetEquipTarget()==c or c:IsRace(RACE_WARRIOR)
+end

--- a/script/c37534148.lua
+++ b/script/c37534148.lua
@@ -1,13 +1,6 @@
 --リボーンリボン
 function c37534148.initial_effect(c)
 	aux.AddEquipProcedure(c,nil,c37534148.filter)
-	--Equip limit
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_EQUIP_LIMIT)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetValue(c37534148.eqlimit)
-	c:RegisterEffect(e2)
 	--special summon
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
@@ -50,7 +43,7 @@ end
 function c37534148.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c40619825.lua
+++ b/script/c40619825.lua
@@ -1,0 +1,50 @@
+--デーモンの斧
+function c40619825.initial_effect(c)
+	aux.AddEquipProcedure(c)
+	--Atk up
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(1000)
+	c:RegisterEffect(e2)
+	--to deck
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(40619825,0))
+	e4:SetCategory(CATEGORY_TODECK)
+	e4:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_CVAL_CHECK)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_TO_GRAVE)
+	e4:SetCondition(c40619825.tdcon)
+	e4:SetCost(c40619825.tdcost)
+	e4:SetTarget(c40619825.tdtg)
+	e4:SetOperation(c40619825.tdop)
+	e4:SetValue(c40619825.valcheck)
+	c:RegisterEffect(e4)
+end
+function c40619825.tdcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+end
+function c40619825.tdcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.GetFlagEffect(tp,40619825)==0 then
+			Duel.RegisterFlagEffect(tp,40619825,RESET_CHAIN,0,1)
+			c40619825[0]=Duel.GetReleaseGroupCount(tp)
+			c40619825[1]=0
+		end
+		return c40619825[0]-c40619825[1]>=1
+	end
+	local g=Duel.SelectReleaseGroup(tp,nil,1,1,nil)
+	Duel.Release(g,REASON_COST)
+end
+function c40619825.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToDeck() end
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
+end
+function c40619825.tdop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsRelateToEffect(e) then
+		Duel.SendtoDeck(e:GetHandler(),nil,0,REASON_EFFECT)
+	end
+end
+function c40619825.valcheck(e)
+	c40619825[1]=c40619825[1]+1
+end

--- a/script/c42709949.lua
+++ b/script/c42709949.lua
@@ -7,13 +7,6 @@ function c42709949.initial_effect(c)
 	e2:SetCode(EFFECT_UPDATE_ATTACK)
 	e2:SetValue(c42709949.value)
 	c:RegisterEffect(e2)
-	--Equip limit
-	local e3=Effect.CreateEffect(c)
-	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetCode(EFFECT_EQUIP_LIMIT)
-	e3:SetValue(1)
-	c:RegisterEffect(e3)
 end
 function c42709949.value(e,c)
 	return Duel.GetMatchingGroupCount(Card.IsCode,0,LOCATION_GRAVE,LOCATION_GRAVE,nil,c:GetCode())*900

--- a/script/c46910446.lua
+++ b/script/c46910446.lua
@@ -7,13 +7,6 @@ function c46910446.initial_effect(c)
 	e2:SetCode(EFFECT_UPDATE_ATTACK)
 	e2:SetValue(c46910446.value)
 	c:RegisterEffect(e2)
-	--Equip limit
-	local e3=Effect.CreateEffect(c)
-	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetCode(EFFECT_EQUIP_LIMIT)
-	e3:SetValue(1)
-	c:RegisterEffect(e3)
 end
 function c46910446.filter(c,code)
 	return c:IsFaceup() and c:IsCode(code)

--- a/script/c48308134.lua
+++ b/script/c48308134.lua
@@ -1,0 +1,55 @@
+--幻煌龍の螺旋突
+--Spiral Crash of the Mythic Radiance Dragon
+--Script by mercury233
+--fixed by MLD
+function c48308134.initial_effect(c)
+	aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsType,TYPE_NORMAL))
+	--pierce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetCode(EFFECT_PIERCE)
+	c:RegisterEffect(e3)
+	--special summon
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(48308134,0))
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_BATTLE_DAMAGE)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCountLimit(1,48308134)
+	e4:SetCondition(c48308134.spcon)
+	e4:SetTarget(c48308134.sptg)
+	e4:SetOperation(c48308134.spop)
+	c:RegisterEffect(e4)
+end
+function c48308134.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp and eg:GetFirst()==e:GetHandler():GetEquipTarget()
+end
+function c48308134.spfilter(c,e,tp)
+	return c:IsCode(56649609) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c48308134.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c48308134.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE)
+end
+function c48308134.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c48308134.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		local tc=g:GetFirst()
+		if Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+			Duel.Equip(tp,c,tc)
+			Duel.SpecialSummonComplete()
+			local g=Duel.GetMatchingGroup(Card.IsPosition,tp,0,LOCATION_MZONE,nil,POS_ATTACK)
+			if g:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(48308134,1)) then
+				Duel.BreakEffect()
+				local sg=g:Select(tp,1,1,nil)
+				Duel.ChangePosition(sg,POS_FACEUP_DEFENSE,POS_FACEDOWN_DEFENSE,0,0)
+			end
+		end
+	end
+end

--- a/script/c49306994.lua
+++ b/script/c49306994.lua
@@ -1,0 +1,113 @@
+--白のヴェール
+function c49306994.initial_effect(c)
+	aux.AddEquipProcedure(c)
+	--Actlimit
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e3:SetTargetRange(0,1)
+	e3:SetValue(c49306994.aclimit)
+	e3:SetCondition(c49306994.actcon)
+	c:RegisterEffect(e3)
+	--disable
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e4:SetCondition(c49306994.discon)
+	e4:SetOperation(c49306994.disop)
+	c:RegisterEffect(e4)
+	--destroy
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(49306994,0))
+	e5:SetCategory(CATEGORY_DESTROY)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e5:SetCode(EVENT_BATTLE_DESTROYING)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetCondition(c49306994.descon)
+	e5:SetTarget(c49306994.destg)
+	e5:SetOperation(c49306994.desop)
+	c:RegisterEffect(e5)
+	--leave
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e6:SetCode(EVENT_LEAVE_FIELD_P)
+	e6:SetOperation(c49306994.checkop)
+	c:RegisterEffect(e6)
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e7:SetCode(EVENT_LEAVE_FIELD)
+	e7:SetLabelObject(e6)
+	e7:SetOperation(c49306994.leave)
+	c:RegisterEffect(e7)
+end
+function c49306994.aclimit(e,re,tp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and not re:GetHandler():IsImmuneToEffect(e)
+end
+function c49306994.actcon(e)
+	local tc=e:GetHandler():GetEquipTarget()
+	return Duel.GetAttacker()==tc or Duel.GetAttackTarget()==tc
+end
+function c49306994.discon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetHandler():GetEquipTarget()
+	return Duel.GetAttacker()==tc or Duel.GetAttackTarget()==tc
+end
+function c49306994.disfilter(c)
+	return aux.disfilter1(c) and c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c49306994.disop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local g=Duel.GetMatchingGroup(c49306994.disfilter,tp,0,LOCATION_ONFIELD,c)
+	local tc=g:GetFirst()
+	while tc do
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE)
+		tc:RegisterEffect(e2)
+		if tc:IsType(TYPE_TRAPMONSTER) then
+			local e3=Effect.CreateEffect(c)
+			e3:SetType(EFFECT_TYPE_SINGLE)
+			e3:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+			e3:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE)
+			tc:RegisterEffect(e3)
+		end
+		tc=g:GetNext()
+	end
+end
+function c49306994.descon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetEquipTarget()==eg:GetFirst()
+end
+function c49306994.filter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c49306994.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c49306994.filter,tp,0,LOCATION_ONFIELD,1,nil) end
+	local sg=Duel.GetMatchingGroup(c49306994.filter,tp,0,LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
+end
+function c49306994.desop(e,tp,eg,ep,ev,re,r,rp)
+	local sg=Duel.GetMatchingGroup(c49306994.filter,tp,0,LOCATION_ONFIELD,nil)
+	Duel.Destroy(sg,REASON_EFFECT)
+end
+function c49306994.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsDisabled() then
+		e:SetLabel(1)
+	else e:SetLabel(0) end
+end
+function c49306994.leave(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if e:GetLabelObject():GetLabel()==0 and c:GetPreviousControler()==tp
+		and c:IsPreviousLocation(LOCATION_SZONE) and c:IsPreviousPosition(POS_FACEUP) then
+		Duel.Damage(tp,3000,REASON_EFFECT)
+	end
+end

--- a/script/c50152549.lua
+++ b/script/c50152549.lua
@@ -1,0 +1,12 @@
+--しびれ薬
+function c50152549.initial_effect(c)
+	aux.AddEquipProcedure(c,nil,c50152549.filter)
+	--atklimit
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_CANNOT_ATTACK)
+	c:RegisterEffect(e2)
+end
+function c50152549.filter(c)
+	return not c:IsRace(RACE_MACHINE)
+end

--- a/script/c75702749.lua
+++ b/script/c75702749.lua
@@ -1,0 +1,55 @@
+--幻煌龍の螺旋絞
+--Spiral Hold of the Mythic Radiance Dragon
+--Script by dest
+--fixed by MLD
+function c75702749.initial_effect(c)
+	aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsType,TYPE_NORMAL))
+	--Atk up
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetValue(500)
+	c:RegisterEffect(e3)
+	--spsummon
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(75702749,0))
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_DAMAGE)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_BATTLE_DESTROYING)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCountLimit(1,75702749)
+	e4:SetCondition(c75702749.spcon)
+	e4:SetTarget(c75702749.sptg)
+	e4:SetOperation(c75702749.spop)
+	c:RegisterEffect(e4)
+end
+function c75702749.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipTarget()
+	return ec and eg:IsContains(ec)
+end
+function c75702749.spfilter(c,e,tp)
+	return c:IsCode(56649609) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c75702749.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c75702749.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,1000)
+end
+function c75702749.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c75702749.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		local tc=g:GetFirst()
+		if Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP)~=0 then
+			Duel.Equip(tp,c,tc)
+			Duel.SpecialSummonComplete()
+			Duel.BreakEffect()
+			Duel.Damage(1-tp,1000,REASON_EFFECT)
+		end
+	end
+end

--- a/script/c88190790.lua
+++ b/script/c88190790.lua
@@ -56,19 +56,8 @@ function c88190790.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	e1:SetReset(RESET_CHAIN)
 	e1:SetLabel(Duel.GetCurrentChain())
 	e1:SetLabelObject(e)
-	e1:SetOperation(c88190790.operation)
+	e1:SetOperation(aux.EquipEquip)
 	Duel.RegisterEffect(e1,tp)
-end
-function c88190790.operation(e,tp,eg,ep,ev,re,r,rp)
-	if re~=e:GetLabelObject() then return end
-	local c=e:GetHandler()
-	if c:IsType(TYPE_EQUIP) and c:IsLocation(LOCATION_SZONE) and c:IsFaceup() then
-		local ct=Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)
-		local tc=Duel.GetChainInfo(Duel.GetCurrentChain(),CHAININFO_TARGET_CARDS):GetFirst()
-		if ct==1 and tc and c:IsRelateToEffect(re) and tc:IsRelateToEffect(re) and tc:IsFaceup() then
-			Duel.Equip(tp,c,tc)
-		end
-	end
 end
 function c88190790.macon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()

--- a/script/c99597615.lua
+++ b/script/c99597615.lua
@@ -1,27 +1,12 @@
 --悪魔のくちづけ
 function c99597615.initial_effect(c)
-	--Activate
-	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetTarget(c99597615.target)
-	e1:SetOperation(c99597615.operation)
-	c:RegisterEffect(e1)
+	aux.AddEquipProcedure(c)
 	--Atk up
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_EQUIP)
 	e2:SetCode(EFFECT_UPDATE_ATTACK)
 	e2:SetValue(700)
 	c:RegisterEffect(e2)
-	--Equip limit
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetCode(EFFECT_EQUIP_LIMIT)
-	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e3:SetValue(1)
-	c:RegisterEffect(e3)
 	--to deck
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(99597615,0))
@@ -35,25 +20,12 @@ function c99597615.initial_effect(c)
 	e4:SetOperation(c99597615.tdop)
 	c:RegisterEffect(e4)
 end
-function c99597615.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
-end
-function c99597615.operation(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
-		Duel.Equip(tp,e:GetHandler(),tc)
-	end
-end
 function c99597615.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function c99597615.tdcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckLPCost(tp,500)
-	else Duel.PayLPCost(tp,500)	end
+	if chk==0 then return Duel.CheckLPCost(tp,500) end
+	Duel.PayLPCost(tp,500)
 end
 function c99597615.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToDeck() end


### PR DESCRIPTION
Dragonic Attack being destroyed after being equipped
Paralyzing Potion cannot be equipped to non-Machines
Equip Spells ruling applied to Spiral Equip Spells