### PR TITLE
Fixed Last Chapter and Ancient Gear Drill

### DIFF
--- a/script/c66970385.lua
+++ b/script/c66970385.lua
@@ -1,0 +1,48 @@
+--聖騎士伝説の終幕
+function c66970385.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCountLimit(1,66970385+EFFECT_COUNT_CODE_OATH)
+	e1:SetCondition(c66970385.condition)
+	e1:SetTarget(c66970385.target)
+	e1:SetOperation(c66970385.activate)
+	c:RegisterEffect(e1)
+end
+function c66970385.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 and Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)>0
+	and Duel.GetLocationCount(tp,LOCATION_SZONE)>1
+end
+function c66970385.filter(c,e,tp)
+	return c:IsSetCard(0x107a) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingTarget(c66970385.eqfilter,tp,LOCATION_GRAVE,0,1,nil,tp,c)
+end
+function c66970385.eqfilter(c,tp,ec)
+	return c:IsSetCard(0x207a) and c:CheckUniqueOnField(tp) and c:CheckEquipTarget(ec)
+end
+function c66970385.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c66970385.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g1=Duel.SelectTarget(tp,c66970385.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	e:SetLabelObject(g1:GetFirst())
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g2=Duel.SelectTarget(tp,c66970385.eqfilter,tp,LOCATION_GRAVE,0,1,1,nil,tp,g1:GetFirst())
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g1,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g2,1,0,0)
+end
+function c66970385.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 or Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
+	local tc=e:GetLabelObject()
+	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local ec=tg:GetFirst()
+	if ec==tc then ec=tg:GetNext() end
+	if tc:IsRelateToEffect(e) and ec:IsRelateToEffect(e) and ec:CheckUniqueOnField(tp) and ec:CheckEquipTarget(tc)
+		and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)>0 then
+		Duel.Equip(tp,ec,tc)
+	end
+end

--- a/script/c67829249.lua
+++ b/script/c67829249.lua
@@ -1,0 +1,54 @@
+--古代の採掘機
+function c67829249.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c67829249.condition)
+	e1:SetCost(c67829249.cost)
+	e1:SetTarget(c67829249.target)
+	e1:SetOperation(c67829249.operation)
+	c:RegisterEffect(e1)
+end
+function c67829249.isfilter(c)
+	return c:IsType(TYPE_FIELD)
+end
+function c67829249.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x7)
+end
+function c67829249.condition(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsExistingMatchingCard(c67829249.isfilter,tp,LOCATION_DECK,0,1,nil)
+	and Duel.IsExistingMatchingCard(c67829249.cfilter,tp,LOCATION_MZONE,0,1,nil)
+	then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+	else return Duel.GetLocationCount(tp,LOCATION_SZONE)>1
+	end
+end
+function c67829249.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
+	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
+end
+function c67829249.filter(c)
+	return c:IsType(TYPE_SPELL) and c:IsSSetable()
+end
+function c67829249.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c67829249.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function c67829249.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)
+	local g=Duel.SelectMatchingCard(tp,c67829249.filter,tp,LOCATION_DECK,0,1,1,nil)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SSet(tp,tc)
+		Duel.ConfirmCards(1-tp,tc)
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CANNOT_TRIGGER)
+		e1:SetReset(RESET_EVENT+0x17a0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_CANNOT_USE_AS_COST)
+		e2:SetReset(RESET_EVENT+0x17a0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e2)
+	end
+end


### PR DESCRIPTION
Both cards could use their effects if there was only 1 S/T Zone vacant. This has been changed to not allow that.