### PR TITLE
Fix for Beginning Knight and Evening Twilight Knight

### DIFF
--- a/script/c32013448.lua
+++ b/script/c32013448.lua
@@ -1,0 +1,128 @@
+--宵闇の騎士
+function c32013448.initial_effect(c)
+	--gain
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetCode(EVENT_BE_MATERIAL)
+	e1:SetCondition(c32013448.mtcon)
+	e1:SetOperation(c32013448.mtop)
+	c:RegisterEffect(e1)
+	--tohand
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_REMOVE)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e2:SetCountLimit(1,32013448)
+	e2:SetCondition(c32013448.thcon)
+	e2:SetTarget(c32013448.thtg)
+	e2:SetOperation(c32013448.thop)
+	c:RegisterEffect(e2)
+end
+function c32013448.mtcon(e,tp,eg,ep,ev,re,r,rp)
+	return r==REASON_RITUAL
+end
+function c32013448.mtop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetFlagEffect(tp,32013448)~=0 then return end
+	local c=e:GetHandler()
+	local g=eg:Filter(Card.IsSetCard,nil,0x10cf)
+	local rc=g:GetFirst()
+	if not rc then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(32013448,0))
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetTarget(c32013448.rmtg)
+	e1:SetOperation(c32013448.rmop)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	rc:RegisterEffect(e1,true)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(32013448,1))
+	e2:SetCategory(CATEGORY_REMOVE)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetTarget(c32013448.rmtg2)
+	e2:SetOperation(c32013448.rmop2)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	rc:RegisterEffect(e2,true)
+	if not rc:IsType(TYPE_EFFECT) then
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_ADD_TYPE)
+		e3:SetValue(TYPE_EFFECT)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		rc:RegisterEffect(e3,true)
+	end
+	rc:RegisterFlagEffect(0,RESET_EVENT+0x1fe0000,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(32013448,3)) --this fixes the text box for BLS, don't touch it
+	Duel.RegisterFlagEffect(tp,32013448,RESET_PHASE+PHASE_END,0,1)
+end
+function c32013448.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsAbleToRemove() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsAbleToRemove,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
+end
+function c32013448.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
+	end
+end
+function c32013448.rmtg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,1,1-tp,LOCATION_HAND)
+end
+function c32013448.rmop2(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_HAND,nil)
+	if g:GetCount()==0 then return end
+	local sg=g:RandomSelect(tp,1)
+	local tc=sg:GetFirst()
+	Duel.Remove(tc,POS_FACEDOWN,REASON_EFFECT)
+	tc:RegisterFlagEffect(32013448,RESET_EVENT+0x1fe0000,0,1)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c32013448.retcon)
+	e1:SetOperation(c32013448.retop)
+	e1:SetLabelObject(tc)
+	e1:SetReset(RESET_PHASE+PHASE_END+RESET_OPPO_TURN)
+	Duel.RegisterEffect(e1,tp)
+end
+function c32013448.retcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:GetFlagEffect(32013448)==0 then
+		e:Reset()
+		return false
+	else
+		return Duel.GetTurnPlayer()~=tp
+	end
+end
+function c32013448.retop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	Duel.SendtoHand(tc,nil,REASON_EFFECT)
+end
+function c32013448.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPreviousLocation(LOCATION_GRAVE)
+end
+function c32013448.thfilter(c)
+	return bit.band(c:GetType(),0x81)==0x81 and c:IsAbleToHand()
+end
+function c32013448.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c32013448.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c32013448.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c32013448.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c6628343.lua
+++ b/script/c6628343.lua
@@ -1,0 +1,98 @@
+--beginning knight - 開闢の騎士
+function c6628343.initial_effect(c)
+	--gain
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetCode(EVENT_BE_MATERIAL)
+	e1:SetCondition(c6628343.mtcon)
+	e1:SetOperation(c6628343.mtop)
+	c:RegisterEffect(e1)
+	--tohand
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_REMOVE)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e2:SetCountLimit(1,6628343)
+	e2:SetCondition(c6628343.thcon)
+	e2:SetTarget(c6628343.thtg)
+	e2:SetOperation(c6628343.thop)
+	c:RegisterEffect(e2)
+end
+function c6628343.mtcon(e,tp,eg,ep,ev,re,r,rp)
+	return r==REASON_RITUAL
+end
+function c6628343.mtop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetFlagEffect(tp,6628343)~=0 then return end
+	local c=e:GetHandler()
+	local g=eg:Filter(Card.IsSetCard,nil,0x10cf)
+	local rc=g:GetFirst()
+	if not rc then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(6628343,0))
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetTarget(c6628343.rmtg)
+	e1:SetOperation(c6628343.rmop)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	rc:RegisterEffect(e1,true)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(6628343,1))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_BATTLE_DESTROYING)
+	e2:SetCondition(c6628343.atcon)
+	e2:SetOperation(c6628343.atop)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	rc:RegisterEffect(e2,true)
+	if not rc:IsType(TYPE_EFFECT) then
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_ADD_TYPE)
+		e3:SetValue(TYPE_EFFECT)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		rc:RegisterEffect(e3,true)
+	end
+	rc:RegisterFlagEffect(0,RESET_EVENT+0x1fe0000,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(6628343,3)) --this fixes the text box for BLS, don't touch it
+	Duel.RegisterFlagEffect(tp,6628343,RESET_PHASE+PHASE_END,0,1)
+end
+function c6628343.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsAbleToRemove() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsAbleToRemove,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
+end
+function c6628343.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
+	end
+end
+function c6628343.atcon(e,tp,eg,ep,ev,re,r,rp)
+	return aux.bdogcon(e,tp,eg,ep,ev,re,r,rp) and e:GetHandler():IsChainAttackable()
+end
+function c6628343.atop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChainAttack()
+end
+function c6628343.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPreviousLocation(LOCATION_GRAVE)
+end
+function c6628343.thfilter(c)
+	return c:GetType()==TYPE_SPELL+TYPE_RITUAL and c:IsAbleToHand()
+end
+function c6628343.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c6628343.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c6628343.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c6628343.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end


### PR DESCRIPTION
Fix for incorrect text giving to BLS ritual monsters that use Beginning Knight and Evening Twilight Knight as tributes.