### PR TITLE
Fixed Performapal Gatling Ghoul

### DIFF
--- a/script/c49820233.lua
+++ b/script/c49820233.lua
@@ -1,0 +1,71 @@
+--EMガトリングール
+--Performapal Gatling Ghoul
+--Script by nekrozar
+--Fixed By: TheOnePharaoh
+function c49820233.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x9f),aux.FilterBoolFunction(c49820233.ffilter),true)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(49820233,0))
+	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCountLimit(1,49820233)
+	e1:SetCondition(c49820233.damcon)
+	e1:SetTarget(c49820233.damtg)
+	e1:SetOperation(c49820233.damop)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_MATERIAL_CHECK)
+	e2:SetValue(c49820233.valcheck)
+	e2:SetLabelObject(e1)
+	c:RegisterEffect(e2)
+end
+function c49820233.ffilter(c)
+	if Card.IsFusionAttribute then
+		return c:IsFusionAttribute(ATTRIBUTE_DARK) and c:IsLevelAbove(5)
+	else
+		return c:IsAttribute(ATTRIBUTE_DARK) and c:IsLevelAbove(5)
+	end
+end
+function c49820233.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
+end
+function c49820233.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,LOCATION_ONFIELD)>0 end
+	local ct=Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,LOCATION_ONFIELD)
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,ct*200)
+	if e:GetLabel()==1 then
+		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_MZONE,nil)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	end
+end
+function c49820233.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+	local ct=Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,LOCATION_ONFIELD)
+	if ct>0 and Duel.Damage(p,ct*200,REASON_EFFECT)~=0 and e:GetLabel()==1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+		local g=Duel.SelectMatchingCard(tp,aux.TRUE,tp,0,LOCATION_MZONE,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.BreakEffect()
+			Duel.HintSelection(g)
+			local dam=g:GetFirst():GetBaseAttack()
+			if Duel.Destroy(g,REASON_EFFECT)~=0 then
+				Duel.Damage(p,dam,REASON_EFFECT)
+			end
+		end
+	end
+end
+function c49820233.valcheck(e,c)
+	local g=c:GetMaterial()
+	if g:IsExists(Card.IsType,1,nil,TYPE_PENDULUM) then
+		e:GetLabelObject():SetLabel(1)
+	else
+		e:GetLabelObject():SetLabel(0)
+	end
+end


### PR DESCRIPTION
it didn't work properly with cards that change the original ATK of a monster on the field for example `shrink` or monsters that has ? ATK and determined their original ATK using their effect for example `Chimeratech Overdragon`.
```and if you do, inflict damage to your opponent equal to the original ATK the destroyed monster had on the field.```