### PR TITLE
Fixed "Gladiator Beast" "Tag Out"

### DIFF
--- a/script/c100217025.lua
+++ b/script/c100217025.lua
@@ -86,7 +86,7 @@ function c100217025.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c100217025.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsAbleToDeckAsCost() end
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
 	Duel.SendtoDeck(c,nil,2,REASON_COST)
 end
 function c100217025.filter(c,e,tp)

--- a/script/c2067935.lua
+++ b/script/c2067935.lua
@@ -1,0 +1,100 @@
+--剣闘獣ラニスタ
+function c2067935.initial_effect(c)
+	--tohand
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(2067935,0))
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c2067935.rmcon)
+	e1:SetTarget(c2067935.rmtg)
+	e1:SetOperation(c2067935.rmop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(2067935,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c2067935.spcon)
+	e2:SetCost(c2067935.spcost)
+	e2:SetTarget(c2067935.sptg)
+	e2:SetOperation(c2067935.spop)
+	c:RegisterEffect(e2)
+end
+function c2067935.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	local st=e:GetHandler():GetSummonType()
+	return st>=(SUMMON_TYPE_SPECIAL+100) and st<(SUMMON_TYPE_SPECIAL+150)
+end
+function c2067935.rmfilter(c)
+	return c:IsSetCard(0x19) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemove()
+end
+function c2067935.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c2067935.rmfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c2067935.rmfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectTarget(tp,c2067935.rmfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
+end
+function c2067935.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		local code=tc:GetOriginalCode()
+		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
+		if c:IsFacedown() or not c:IsRelateToEffect(e) then return end
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetCode(EFFECT_CHANGE_CODE)
+		e1:SetValue(code)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetDescription(aux.Stringid(2067935,2))
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_PHASE+PHASE_END)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+		e2:SetCountLimit(1)
+		e2:SetRange(LOCATION_MZONE)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e2:SetLabelObject(e1)
+		e2:SetOperation(c2067935.rstop)
+		c:RegisterEffect(e2)
+	end
+end
+function c2067935.rstop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=e:GetLabelObject()
+	e1:Reset()
+	Duel.HintSelection(Group.FromCards(c))
+	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+end
+function c2067935.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c2067935.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c2067935.filter(c,e,tp)
+	return not c:IsCode(2067935) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,112,tp,false,false)
+end
+function c2067935.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c2067935.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c2067935.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c2067935.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,112,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c25924653.lua
+++ b/script/c25924653.lua
@@ -1,0 +1,111 @@
+--剣闘獣ダリウス
+function c25924653.initial_effect(c)
+	--grave special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(25924653,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c25924653.spgcon)
+	e1:SetTarget(c25924653.spgtg)
+	e1:SetOperation(c25924653.spgop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(25924653,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c25924653.spcon)
+	e2:SetCost(c25924653.spcost)
+	e2:SetTarget(c25924653.sptg)
+	e2:SetOperation(c25924653.spop)
+	c:RegisterEffect(e2)
+	--leave field
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_LEAVE_FIELD)
+	e3:SetOperation(c25924653.leave)
+	c:RegisterEffect(e3)
+end
+function c25924653.spgcon(e,tp,eg,ep,ev,re,r,rp)
+	local st=e:GetHandler():GetSummonType()
+	return st>=(SUMMON_TYPE_SPECIAL+100) and st<(SUMMON_TYPE_SPECIAL+150)
+end
+function c25924653.spgfilter(c,e,tp)
+	return c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,104,tp,false,false)
+end
+function c25924653.spgtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c25924653.spgfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c25924653.spgfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c25924653.spgfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c25924653.spgop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,104,tp,tp,false,false,POS_FACEUP)>0
+		and c:IsFaceup() and c:IsRelateToEffect(e) then
+		c:SetCardTarget(tc)
+		tc:RegisterFlagEffect(25924654,RESET_EVENT+0x53e0000,0,1)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetCondition(c25924653.discon)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_CHAIN_SOLVING)
+		e2:SetRange(LOCATION_MZONE)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetOperation(c25924653.disop)
+		c:RegisterEffect(e2)
+	end
+end
+function c25924653.discon(e)
+	return e:GetOwner():IsHasCardTarget(e:GetHandler())
+end
+function c25924653.disop(e,tp,eg,ep,ev,re,r,rp)
+	if re:GetHandler():GetFlagEffect(25924654)~=0 then
+		Duel.NegateEffect(ev)
+	end
+end
+function c25924653.leave(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=c:GetFirstCardTarget()
+	if tc and tc:IsLocation(LOCATION_MZONE) and tc:GetFlagEffect(25924654)~=0 then
+		Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)
+	end
+end
+function c25924653.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c25924653.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c25924653.filter(c,e,tp)
+	return not c:IsCode(25924653) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,104,tp,false,false)
+end
+function c25924653.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c25924653.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c25924653.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c25924653.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,104,tp,tp,false,false,POS_FACEUP)		
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c2619149.lua
+++ b/script/c2619149.lua
@@ -1,0 +1,70 @@
+--剣闘獣サムニテ
+function c2619149.initial_effect(c)
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(2619149,0))
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetCode(EVENT_BATTLE_DESTROYING)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCondition(c2619149.scon)
+	e1:SetTarget(c2619149.stg)
+	e1:SetOperation(c2619149.sop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(2619149,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c2619149.spcon)
+	e2:SetCost(c2619149.spcost)
+	e2:SetTarget(c2619149.sptg)
+	e2:SetOperation(c2619149.spop)
+	c:RegisterEffect(e2)
+end
+function c2619149.scon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:GetFlagEffect(2619149)>0 and aux.bdogcon(e,tp,eg,ep,ev,re,r,rp)
+end
+function c2619149.sfilter(c)
+	return c:IsSetCard(0x19) and c:IsAbleToHand()
+end
+function c2619149.stg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c2619149.sfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,0,0)
+end
+function c2619149.sop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c2619149.sfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c2619149.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c2619149.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c2619149.filter(c,e,tp)
+	return not c:IsCode(2619149) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,108,tp,false,false)
+end
+function c2619149.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c2619149.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c2619149.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c2619149.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,108,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c31247589.lua
+++ b/script/c31247589.lua
@@ -1,0 +1,51 @@
+--剣闘獣ディカエリィ
+function c31247589.initial_effect(c)
+	--double attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_EXTRA_ATTACK)
+	e1:SetCondition(c31247589.dacon)
+	e1:SetValue(1)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(31247589,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c31247589.spcon)
+	e2:SetCost(c31247589.spcost)
+	e2:SetTarget(c31247589.sptg)
+	e2:SetOperation(c31247589.spop)
+	c:RegisterEffect(e2)
+end
+function c31247589.dacon(e)
+	return e:GetHandler():GetFlagEffect(31247589)>0
+end
+function c31247589.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c31247589.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c31247589.filter(c,e,tp)
+	return not c:IsCode(31247589) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,107,tp,false,false)
+end
+function c31247589.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c31247589.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,0,0)
+end
+function c31247589.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c31247589.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,107,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c41470137.lua
+++ b/script/c41470137.lua
@@ -1,0 +1,72 @@
+--剣闘獣ベストロウリィ
+function c41470137.initial_effect(c)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(41470137,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c41470137.descon)
+	e1:SetTarget(c41470137.destg)
+	e1:SetOperation(c41470137.desop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(41470137,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c41470137.spcon)
+	e2:SetCost(c41470137.spcost)
+	e2:SetTarget(c41470137.sptg)
+	e2:SetOperation(c41470137.spop)
+	c:RegisterEffect(e2)
+end
+function c41470137.descon(e,tp,eg,ep,ev,re,r,rp)
+	local st=e:GetHandler():GetSummonType()
+	return st>=(SUMMON_TYPE_SPECIAL+100) and st<(SUMMON_TYPE_SPECIAL+150)
+end
+function c41470137.desfilter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c41470137.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c41470137.desfilter(chkc) end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c41470137.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c41470137.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end
+function c41470137.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c41470137.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c41470137.filter(c,e,tp)
+	return not c:IsCode(41470137) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,102,tp,false,false)
+end
+function c41470137.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c41470137.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c41470137.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c41470137.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,102,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c4253484.lua
+++ b/script/c4253484.lua
@@ -1,0 +1,51 @@
+--剣闘獣ホプロムス
+function c4253484.initial_effect(c)
+	--def
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SET_BASE_DEFENSE)
+	e1:SetCondition(c4253484.defcon)
+	e1:SetValue(2400)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(4253484,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c4253484.spcon)
+	e2:SetCost(c4253484.spcost)
+	e2:SetTarget(c4253484.sptg)
+	e2:SetOperation(c4253484.spop)
+	c:RegisterEffect(e2)
+end
+function c4253484.defcon(e)
+	return e:GetHandler():GetFlagEffect(4253484)>0
+end
+function c4253484.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c4253484.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c4253484.filter(c,e,tp)
+	return not c:IsCode(4253484) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,101,tp,false,false)
+end
+function c4253484.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c4253484.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c4253484.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c4253484.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,101,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c42592719.lua
+++ b/script/c42592719.lua
@@ -1,0 +1,66 @@
+--剣闘獣アレクサンデル
+function c42592719.initial_effect(c)
+	--immune spell
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_IMMUNE_EFFECT)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c42592719.imcon)
+	e1:SetValue(c42592719.imfilter)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(42592719,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c42592719.spcon)
+	e2:SetCost(c42592719.spcost)
+	e2:SetTarget(c42592719.sptg)
+	e2:SetOperation(c42592719.spop)
+	c:RegisterEffect(e2)
+	--spsummon limit
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e3:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e3:SetValue(c42592719.splimit)
+	c:RegisterEffect(e3)
+end
+function c42592719.splimit(e,se,sp,st)
+	return st==(SUMMON_TYPE_SPECIAL+107)
+end
+function c42592719.imcon(e)
+	return e:GetHandler():GetFlagEffect(42592719)>0
+end
+function c42592719.imfilter(e,te)
+	return te:IsActiveType(TYPE_SPELL)
+end
+function c42592719.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c42592719.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c42592719.filter(c,e,tp)
+	return not c:IsCode(42592719) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,111,tp,false,false)
+end
+function c42592719.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c42592719.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c42592719.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c42592719.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,111,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c57731460.lua
+++ b/script/c57731460.lua
@@ -1,0 +1,72 @@
+--剣闘獣エクイテ
+function c57731460.initial_effect(c)
+	--tohand
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(57731460,0))
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c57731460.retcon)
+	e1:SetTarget(c57731460.rettg)
+	e1:SetOperation(c57731460.retop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(57731460,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c57731460.spcon)
+	e2:SetCost(c57731460.spcost)
+	e2:SetTarget(c57731460.sptg)
+	e2:SetOperation(c57731460.spop)
+	c:RegisterEffect(e2)
+end
+function c57731460.retcon(e,tp,eg,ep,ev,re,r,rp)
+	local st=e:GetHandler():GetSummonType()
+	return st>=(SUMMON_TYPE_SPECIAL+100) and st<(SUMMON_TYPE_SPECIAL+150)
+end
+function c57731460.retfilter(c)
+	return c:IsSetCard(0x19) and c:IsAbleToHand()
+end
+function c57731460.rettg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c57731460.retfilter(chkc) end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c57731460.retfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,g:GetCount(),0,0)
+end
+function c57731460.retop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+	end
+end
+function c57731460.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c57731460.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c57731460.filter(c,e,tp)
+	return not c:IsCode(57731460) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,103,tp,false,false)
+end
+function c57731460.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c57731460.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c57731460.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c57731460.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,103,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c5975022.lua
+++ b/script/c5975022.lua
@@ -1,0 +1,72 @@
+--剣闘獣ムルミロ
+function c5975022.initial_effect(c)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(5975022,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c5975022.descon)
+	e1:SetTarget(c5975022.destg)
+	e1:SetOperation(c5975022.desop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(5975022,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c5975022.spcon)
+	e2:SetCost(c5975022.spcost)
+	e2:SetTarget(c5975022.sptg)
+	e2:SetOperation(c5975022.spop)
+	c:RegisterEffect(e2)
+end
+function c5975022.descon(e,tp,eg,ep,ev,re,r,rp)
+	local st=e:GetHandler():GetSummonType()
+	return st>=(SUMMON_TYPE_SPECIAL+100) and st<(SUMMON_TYPE_SPECIAL+150)
+end
+function c5975022.desfilter(c)
+	return c:IsFaceup() 
+end
+function c5975022.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:GetLocation()==LOCATION_MZONE and c5975022.desfilter(chkc) end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c5975022.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c5975022.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end
+function c5975022.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c5975022.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c5975022.filter(c,e,tp)
+	return not c:IsCode(5975022) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,105,tp,false,false)
+end
+function c5975022.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c5975022.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c5975022.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c5975022.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,105,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c612115.lua
+++ b/script/c612115.lua
@@ -1,0 +1,69 @@
+--剣闘獣レティアリィ
+function c612115.initial_effect(c)
+	--remove
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(612115,0))
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c612115.rmcon)
+	e1:SetTarget(c612115.rmtg)
+	e1:SetOperation(c612115.rmop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(612115,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c612115.spcon)
+	e2:SetCost(c612115.spcost)
+	e2:SetTarget(c612115.sptg)
+	e2:SetOperation(c612115.spop)
+	c:RegisterEffect(e2)
+end
+function c612115.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	local st=e:GetHandler():GetSummonType()
+	return st>=(SUMMON_TYPE_SPECIAL+100) and st<(SUMMON_TYPE_SPECIAL+150)
+end
+function c612115.rmtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and chkc:IsAbleToRemove() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
+end
+function c612115.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
+	end
+end
+function c612115.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c612115.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c612115.filter(c,e,tp)
+	return not c:IsCode(612115) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,109,tp,false,false)
+end
+function c612115.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c612115.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c612115.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c612115.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,109,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c65984457.lua
+++ b/script/c65984457.lua
@@ -1,0 +1,33 @@
+--剣闘獣トラケス
+function c65984457.initial_effect(c)
+	--draw
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(65984457,0))
+	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c65984457.spcon)
+	e1:SetCost(c65984457.spcost)
+	e1:SetTarget(c65984457.sptg)
+	e1:SetOperation(c65984457.spop)
+	c:RegisterEffect(e1)
+end
+function c65984457.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(65984457)>0 and e:GetHandler():GetBattledGroupCount()>0
+end
+function c65984457.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c65984457.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c65984457.spop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/script/c7573135.lua
+++ b/script/c7573135.lua
@@ -1,0 +1,96 @@
+--剣闘獣アウグストル
+function c7573135.initial_effect(c)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(7573135,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c7573135.hspcon)
+	e1:SetTarget(c7573135.hsptg)
+	e1:SetOperation(c7573135.hspop)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(7573135,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c7573135.spcon)
+	e2:SetCost(c7573135.spcost)
+	e2:SetTarget(c7573135.sptg)
+	e2:SetOperation(c7573135.spop)
+	c:RegisterEffect(e2)
+end
+function c7573135.hspcon(e,tp,eg,ep,ev,re,r,rp)
+	local st=e:GetHandler():GetSummonType()
+	return st>=(SUMMON_TYPE_SPECIAL+100) and st<(SUMMON_TYPE_SPECIAL+150)
+end
+function c7573135.hspfilter(c,e,tp)
+	return c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,113,tp,false,false)
+end
+function c7573135.hsptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c7573135.hspfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c7573135.hspop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c7573135.hspfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,113,tp,tp,false,false,POS_FACEUP_DEFENSE)
+		local fid=e:GetHandler():GetFieldID()
+		tc:RegisterFlagEffect(7573135,RESET_EVENT+0x1fe0000,0,1,fid)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_PHASE+PHASE_END)
+		e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+		e1:SetCountLimit(1)
+		e1:SetLabel(fid)
+		e1:SetLabelObject(tc)
+		e1:SetCondition(c7573135.retcon)
+		e1:SetOperation(c7573135.retop)
+		Duel.RegisterEffect(e1,tp)
+	end
+end
+function c7573135.retcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:GetFlagEffectLabel(7573135)~=e:GetLabel() then
+		e:Reset()
+		return false
+	else return true end
+end
+function c7573135.retop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)
+end
+function c7573135.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c7573135.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c7573135.filter(c,e,tp)
+	return c:IsSetCard(0x19) and not c:IsCode(7573135) and c:IsCanBeSpecialSummoned(e,113,tp,false,false)
+end
+function c7573135.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c7573135.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c7573135.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c7573135.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,113,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c78868776.lua
+++ b/script/c78868776.lua
@@ -1,0 +1,51 @@
+--剣闘獣ラクエル
+function c78868776.initial_effect(c)
+	--atk
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SET_BASE_ATTACK)
+	e1:SetCondition(c78868776.atkcon)
+	e1:SetValue(2100)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(78868776,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c78868776.spcon)
+	e2:SetCost(c78868776.spcost)
+	e2:SetTarget(c78868776.sptg)
+	e2:SetOperation(c78868776.spop)
+	c:RegisterEffect(e2)
+end
+function c78868776.atkcon(e)
+	return e:GetHandler():GetFlagEffect(78868776)>0
+end
+function c78868776.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c78868776.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c78868776.filter(c,e,tp)
+	return not c:IsCode(78868776) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,100,tp,false,false)
+end
+function c78868776.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c78868776.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c78868776.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c78868776.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,100,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end

--- a/script/c79580323.lua
+++ b/script/c79580323.lua
@@ -1,0 +1,75 @@
+--剣闘獣スパルティクス
+function c79580323.initial_effect(c)
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(79580323,0))
+	e1:SetCategory(CATEGORY_SEARCH+CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetTarget(c79580323.stg)
+	e1:SetOperation(c79580323.sop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(79580323,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c79580323.spcon)
+	e2:SetCost(c79580323.spcost)
+	e2:SetTarget(c79580323.sptg)
+	e2:SetOperation(c79580323.spop)
+	c:RegisterEffect(e2)
+	--spsummon limit
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e3:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e3:SetValue(c79580323.splimit)
+	c:RegisterEffect(e3)
+end
+function c79580323.splimit(e,se,sp,st)
+	return st==(SUMMON_TYPE_SPECIAL+101)
+end
+function c79580323.sfilter(c)
+	return c:IsSetCard(0x19) and c:IsType(TYPE_EQUIP) and c:IsAbleToHand()
+end
+function c79580323.stg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,0,0)
+end
+function c79580323.sop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c79580323.sfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c79580323.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function c79580323.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckOrExtraAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function c79580323.filter(c,e,tp)
+	return not c:IsCode(79580323) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,110,tp,false,false)
+end
+function c79580323.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(c79580323.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c79580323.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c79580323.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,110,tp,tp,false,false,POS_FACEUP)
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+0x1ff0000,0,0)
+	end
+end


### PR DESCRIPTION
Fixed to function with Extra Deck monsters that copies effects such as Starving Venom Fusion Dragon
Cards fixed:
Augustus
Alexander (also fixed to disallow Pendulum Summoning it)
Spartacus (also fixed to disallow Pendulum Summoning it)
Noxious
Lanista
Laquari
Darius
Dimacari
Equeste
Bestiri
Holpomus
Samnite
Torax
Retari
Murmillo