### PR TITLE
fix for lancer dragon

### DIFF
--- a/script/c83347294.lua
+++ b/script/c83347294.lua
@@ -37,7 +37,7 @@ function c83347294.initial_effect(c)
 end
 function c83347294.cfilter(c,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsType(TYPE_PENDULUM)
-		and c:IsPreviousLocation(LOCATION_MZONE) and (c:GetPreviousPosition()==POS_FACEUP or c:IsReason(REASON_BATTLE)) and c:GetPreviousControler()==tp
+		and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousControler()==tp
 end
 function c83347294.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c83347294.cfilter,1,nil,tp)


### PR DESCRIPTION
check previous position