### PR TITLE
Updated TCG Forbidden/Limited List

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -1,188 +1,187 @@
-#[2017.4 TCG][2017.4 OCG]]2017.4 Worlds][2017.4 Traditional][2017.4 Anime][[Generation DM][Generation GX][Generation 5ds][Generation ZEXAL]
-!2017.4 TCG
+#[2017.6 TCG][2017.4 OCG]]2017.4 Worlds][2017.4 Traditional][2017.4 Anime][[Generation DM][Generation GX][Generation 5ds][Generation ZEXAL]
+!2017.6 TCG
 #forbidden
-53804307 0
-82301904 0
-34124316 0
-69015963 0
-56570271 0
-8903700 0
-40044918 0
-78706415 0
-93369354 0
-34206604 0
-21593977 0
-96782886 0
-33508719 0
-79106360 0
-90411554 0
-90307777 0
-88071625 0
-20663556 0
-89399912 0
-26400609 0
-33184167 0
-44910027 0
-78010363 0
-3078576 0
-20366274 0
-46772449 0
-34086406 0
-54719828 0
-81122844 0
-69243953 0
-72892473 0
-57953380 0
-4031928 0
-60682203 0
-17375316 0
-44763025 0
-23557835 0
-27970830 0
-42703248 0
-79571449 0
-18144507 0
-18144506 0
-19613556 0
-85602018 0
-34906152 0
-46411259 0
-41482598 0
-83764718 0
-83764719 0
-74191942 0
-67169062 0
-55144522 0
-70828912 0
-45986603 0
-46448938 0
-48130397 0
-27770341 0
-42829885 0
-28566710 0
-27174286 0
-93016201 0
-57585212 0
-3280747 0
-41420027 0
-35316708 0
-64697231 0
-80604091 0
-80604092 0
-7563579 0
-68819554 0
-18326736 0
-67616300 0
-31222701 0
-27279764 0
-35059553 0
-17330916 0
+53804307 0 --Blaster, Dragon Ruler of Infernos			MONSTERS START HERE
+89399912 0 --Tempest, Dragon Ruler of Storms
+26400609 0 --Tidal, Dragon Ruler of Waterfalls
+90411554 0 --Redox, Dragon Ruler of Boulders
+82301904 0 --Chaos Emperor Dragon - Envoy of the End
+34124316 0 --Cyber jar
+69015963 0 --Cyber Stein
+56570271 0 --Destiny Hero - Disk Commander
+8903700 0 --Djinn Releaser of Rituals
+40044918 0 --Elemental Hero Stratos
+78706415 0 --Fiber Jar
+93369354 0 --Fishborg Blaster
+34206604 0 --Magical Scientist
+21593977 0 --Makyura the Destructor
+96782886 0 --Mind Master
+33508719 0 --Morphing Jar
+79106360 0 --Morphing Jar #2
+90307777 0 --Shurit, Strategist of the Nekroz
+88071625 0 --The Tyrant Neptune
+20663556 0 --Substitoad
+33184167 0 --Tribe-Infecting Virus
+44910027 0 --Victory Dragon
+78010363 0 --Witch of the Black Forest
+3078576 0 --Yata-Garasu
+27279764 0 --Apoqliphort Towers
+17330916 0 --Performapal Monkeyboard
+7563579 0 --Performage PlushFire
+68819554 0 --Performage Damage Juggler
+31178212 0 --Majespecter Unicorn - Kirin
+20366274 0 --El Shaddoll Construct
+17412721 0 --Elder Entity Norden
+46772449 0 --Evilswarm Exciton Knight
+18326736 0 --Tellarknight Ptolomaeus
+34086406 0 --Lavalval Chain
+54719828 0 --Number 16: Shock Master
+81122844 0 --Wind-Up Carrier Zenmaity
+69243953 0 --Butterfly Dagger - Elma					SPELLS START HERE
+67616300 0 --Chicken Game
+31222701 0 --Wavering Eyes
+35059553 0 --Kaiser Colloseum
+72892473 0 --Card Destruction
+57953380 0 --Card of Safe Return
+4031928 0 --Change of Heart
+60682203 0 --Cold Wave
+17375316 0 --Confiscation
+44763025 0 --Deliquent Duo
+23557835 0 --Dimension Fusion
+42703248 0 --Giant Trunade
+79571449 0 --Graceful Charity
+18144507 0 --Harpie's Feather Duster
+18144506 0 --Harpie's Feather Duster
+42829885 0 --The Forceful Sentry
+19613556 0 --Heavy Storm
+85602018 0 --Last Will
+46411259 0 --Metamorphosis
+83764718 0 --Monster Reborn
+83764719 0 --Monster Reborn
+74191942 0 --Painful Choice
+67169062 0 --Pot of Avarice
+55144522 0 --Pot of greed
+27970830 0 --Gateway of the Six
+34906152 0 --Mass Driver
+41482598 0 --Mirage of Nightmare
+70828912 0 --Premature Burial
+45986603 0 --Snatch Steal
+46448938 0 --Spellbook of Judgement
+48130397 0 --Super Polymerization
+27770341 0 --Super Rejuvenation
+28566710 0 --Last Turn								TRAPS START HERE
+27174286 0 --Return from the Different Dimension
+93016201 0 --Royal Oppression
+57585212 0 --Self-Destruct Button
+3280747 0 --Sixth Sense
+41420027 0 --Solemn Judgement
+35316708 0 --Time Seal
+64697231 0 --Trap Dustshot
+80604091 0 --Ultimate Offering
+80604092 0 --Ultimate Offering
+5851097 0 --Vanity's Emptiness
 #limit
-50321796 1
-7902349 1
-14878871 1
-44519536 1
-70903634 1
-8124921 1
-65518099 1
-85103922 1
-72989439 1
-15341821 1
-65192027 1
-78868119 1
-33396948 1
-64034255 1
-20758643 1
-99177923 1
-68184115 1
-69207766 1
-41386308 1
-80344569 1
-16226786 1
-88264978 1
-61740673 1
-85138716 1
-10802915 1
-45222299 1
-11877465 1
-87910978 1
-77565204 1
-26674724 1
-89463537 1
-48063985 1
-70583986 1
-52687916 1
-90953320 1
-14087893 1
-48976825 1
-81674782 1
-15854426 1
-6417578 1
-95308449 1
-81439173 1
-66957584 1
-23171610 1
-37520316 1
-43040603 1
-33782437 1
-2295440 1
-96729612 1
-12580477 1
-32807846 1
-74845897 1
-72405967 1
-17639150 1
-54447022 1
-45305419 1
-29401950 1
-94192409 1
-54974237 1
-9059700 1
-30241314 1
-32723153 1
-83555666 1
-83555667 1
-82732705 1
-84749824 1
-73599290 1
-53582587 1
-5851097 0
-17078030 1
-40318957 1
-92746535 1
-17412721 1
-18239909 1
-14733538 1
-58577036 1
-70368879 1
-57143342 1
-55885348 1
-96570609 1
-31178212 0
-27552504 1
-67723438 1
-22842126 1
-53208660 1
-79844764 1
-23434538 1
+7902349 1 --Left Arm of the forbidden one				MONSTERS START HERE
+44519536 1 --Left Leg of the forbidden one
+70903634 1 --Right Arm of the forbidden one
+8124921 1 --Right Leg of the forbidden one
+65518099 1 --Qliporth Scout
+33396948 1 --Exxodia the Forbidden One
+14878871 1 --Rescue Cat
+85103922 1 --Artifact Moraltach
+72989439 1 --Black Luster Soldier - Envoy of the Beginning
+15341821 1 --Dandylion
+65192027 1 --Dark Armed Dragon
+78868119 1 --Deep Sea Diva
+64034255 1 --Genex Ally birdman
+20758643 1 --Graff, Malembrance of the Burning Abyss
+99177923 1 --Infernity Archfiend
+68184115 1 --Inzektor DragonFly
+69207766 1 --Inzektor Hornet
+41386308 1 --Mathematician
+80344569 1 --Neo-Spacian Grand Mole
+16226786 1 --Night Assailant
+88264978 1 --Red-eyes Darkness Metal Dragon
+61740673 1 --Imperial Order
+85138716 1 --Rescue Rabbit
+10802915 1 --Tour Guide From the Underworld
+81275020 1 --Speedroid Terrortop
+57143342 1 --Cir, Malebranche of the Burning Abyss
+55885348 1 --Kozmo Dark Destroyer
+96570609 1 --Ether the Heavenly monarch
+23434538 1 --Maxx "C"
+92746535 1 --Luster Pendulum, the Dracoslayer
+45222299 1 --Evigishki Gustkraken
+11877465 1 --Evigishki Mind Augus
+26674724 1 --Nekroz of Brionac
+89463537 1 --Nekroz of Unicore
+50321796 1 --Brionac, Dragon of Ice Barrier
+18239909 1 --Ignister Prominence, the Blasting Dracoslayer
+48063985 1 --Ritual Beast Ulti-Cannahawk
+70583986 1 --Dewloren, Tiger King of the Ice Barrier
+52687916 1 --Trishula, Dragon of the Ice Barrier
+90953320 1 --T.G. Hyper Librarian
+27552504 1 --Beatrice, Lady of Eternal
+87910978 1 --Brain Control							SPELLS START HERE
+77565204 1 --Future Fusion
+14087893 1 --Book of Moon
+11110587 1 --That Grass Looks Greener
+48976825 1 --Burial from a Different Dimension
+81674782 1 --Dimensional Fissure
+6417578 1 --El Shaddoll Fusion
+95308449 1 --Final Countdown
+81439173 1 --Foolish Burial
+66957584 1 --Infernity Launcher
+23171610 1 --Limiter Removal
+37520316 1 --Mind Control
+43040603 1 --Monster Gate
+33782437 1 --One Day of Peace
+2295440 1 --One for one
+96729612 1 --Preparation of Rites
+12580477 1 --Raigeki
+32807846 1 --Reinforcement of the Army
+74845897 1 --Rekindling
+72405967 1 --Royal Tribute
+17639150 1 --Saqlifice
+54447022 1 --Soul Charge
+45305419 1 --Symbol of Heritage
+14733538 1 --Draco Face-off
+58577036 1 --Reasoning
+70368879 1 --Upstart Goblin
+67723438 1 --Emergency Teleporter
+22842126 1 --Phanteism of the Monarchs
+79844764 1 --The Monarchs Stormforth
+15854426 1 --Divine Wind of the Mist Valley
+29401950 1 --Bottomless Trap Hole					TRAPS START HERE
+94192409 1 --Compulsory Evacuation Device
+54974237 1 --Eradicator Epidemic Virus
+32723153 1 --Magical Explosion
+53582587 1 --Torrential Tribute
+83555666 1 --Ring of Destruction
+83555667 1 --Ring of Destruction
+82732705 1 --Skill Drain
+73599290 1 --Soul Drain
+30241314 1 --Macro Cosmos
+17078030 1 --Wall of Revealing light
+9059700 1 --Infernity Barrier
+84749824 1 --Solemn Warning
 #semi limit
-72714461 2
-74311226 2
-85087012 2
-37742478 2
-28297833 2
-423585 2
-91623717 2
-94886282 2
-53129443 2
-62265044 2
-36468556 2
-29843091 2
-14943837 2
-71564252 2
-78872731 2
-59297550 2
-99330325 2
+74311226 2 --Atlantean Dragons
+85087012 2 --Card Tropper
+37742478 2 --Honest
+28297833 2 --Necroface
+423585 2 --Summoner Monk
+14943837 2 --Debris Dragon
+71564252 2 --Thunder King Rai-Oh
+78872731 2 --Zoodiac Ratpier
+59297550 2 --Wind-up Magician
+99330325 2 --Interrupted Kaiju Slumber
+94886282 2 --Charge of the Light Brigade
+53129443 2 --Dark Hole
+91623717 2 --Chain Strike
+62265044 2 --Dragon Ravine
+36468556 2 --Ceasefire
+29843091 2 --Ojama Trio
 
 !2017.4 OCG
 #forbidden


### PR DESCRIPTION
Implemented 12th June F/L TCG list. 
All the entries for the TCG banlist were labeled.
Also, different cards types (spells/monsters/traps) that were mixed, are now in order (i suggest to keep it that way while editing the file)