### PR TITLE
Fixed Todally Awesome and Spellbing Circle

### DIFF
--- a/script/c18807108.lua
+++ b/script/c18807108.lua
@@ -1,0 +1,56 @@
+--六芒星の呪縛
+function c18807108.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_POSITION)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetTarget(c18807108.target)
+	e1:SetOperation(c18807108.operation)
+	c:RegisterEffect(e1)
+	--Destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCondition(c18807108.descon)
+	e2:SetOperation(c18807108.desop)
+	c:RegisterEffect(e2)
+	e1:SetLabelObject(e2)
+end
+function c18807108.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) end
+	if chk==0 then return Duel.IsExistingTarget(nil,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	Duel.SelectTarget(tp,nil,tp,0,LOCATION_MZONE,1,1,nil)
+end
+function c18807108.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
+		c:SetCardTarget(tc)
+		c:CreateRelation(tc,RESET_EVENT+0x1fe0000)
+		e:GetLabelObject():SetLabelObject(tc)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE)
+		e1:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+		e1:SetReset(RESET_EVENT+0x1fc0000)
+		e1:SetCondition(c18807108.rcon)
+		tc:RegisterEffect(e1,true)
+		local e2=e1:Clone()
+		e2:SetCode(EFFECT_CANNOT_ATTACK)
+		tc:RegisterEffect(e2,true)
+	end
+end
+function c18807108.rcon(e)
+	return not e:GetHandler():IsImmuneToEffect(e) and e:GetOwner():IsRelateToCard(e:GetHandler())
+end
+function c18807108.descon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetHandler():GetFirstCardTarget()
+	return tc and eg:IsContains(tc) and tc:IsReason(REASON_DESTROY)
+end
+function c18807108.desop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Destroy(e:GetHandler(),REASON_EFFECT)
+end

--- a/script/c90809975.lua
+++ b/script/c90809975.lua
@@ -32,7 +32,7 @@ function c90809975.initial_effect(c)
 	c:RegisterEffect(e2)
 	--to hand
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(90809975,2))
+	e3:SetDescription(aux.Stringid(90809975,3))
 	e3:SetCategory(CATEGORY_TOHAND)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e3:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
@@ -94,7 +94,7 @@ function c90809975.negop(e,tp,eg,ep,ev,re,r,rp)
 	if rc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and not rc:IsLocation(LOCATION_HAND+LOCATION_DECK) then
 		if rc:IsType(TYPE_MONSTER) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 			and rc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
-			and Duel.SelectYesNo(tp,aux.Stringid(90809975,3)) then
+			and Duel.SelectYesNo(tp,aux.Stringid(90809975,2)) then
 			Duel.BreakEffect()
 			Duel.SpecialSummon(rc,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
 			Duel.ConfirmCards(1-tp,rc)


### PR DESCRIPTION
Small fix for Toadally Awesome: was using an incorrect dialogue box while setting the destroyed monster.
Updated Spellbing Circle's destruction effect condition to correct handle the situation showed in this report https://www.ygopro.co/Forum/tabid/95/g/posts/t/37935/Spellbinding-Circle-seems-to-target-returning-monster.