### PR TITLE
Fixed the Summoning Effect of Astrograph Sorcerer

### DIFF
--- a/script/c76794549.lua
+++ b/script/c76794549.lua
@@ -1,5 +1,4 @@
 --アストログラフ・マジシャン
---fixed by MLD
 function c76794549.initial_effect(c)
 	aux.EnablePendulumAttribute(c)
 	--pendulum set/spsummon
@@ -15,7 +14,7 @@ function c76794549.initial_effect(c)
 	--Special Summon
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(76794549,3))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_SEARCH)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_DESTROYED)
 	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
@@ -34,6 +33,25 @@ function c76794549.initial_effect(c)
 	e3:SetTarget(c76794549.hntg)
 	e3:SetOperation(c76794549.hnop)
 	c:RegisterEffect(e3)
+	if not c76794549.global_check then
+		c76794549.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DESTROYED)
+		ge1:SetOperation(c76794549.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function c76794549.checkop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	while tc do
+		if tc:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED) then
+			tc:RegisterFlagEffect(76794549,RESET_EVENT+0x1f20000+RESET_PHASE+PHASE_END,0,1)
+		elseif tc:IsLocation(LOCATION_EXTRA) then
+			tc:RegisterFlagEffect(76794549,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+		end
+		tc=eg:GetNext()
+	end
 end
 function c76794549.rpfilter(c,e,tp)
 	return c:IsCode(94415058) and (not c:IsForbidden()
@@ -76,7 +94,7 @@ function c76794549.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end
 function c76794549.thfilter1(c,tp,id)
-	return c:IsType(TYPE_MONSTER) and c:IsReason(REASON_DESTROY) and c:GetTurnID()==id
+	return c:IsType(TYPE_MONSTER) and c:GetFlagEffect(76794549)~=0
 		and (c:IsLocation(LOCATION_GRAVE) or c:IsFaceup())
 		and Duel.IsExistingMatchingCard(c76794549.thfilter2,tp,LOCATION_DECK,0,1,nil,c:GetCode())
 end
@@ -98,8 +116,6 @@ function c76794549.spop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.SendtoHand(sg,nil,REASON_EFFECT)
 			Duel.ConfirmCards(1-tp,sg)
 		end
-	elseif Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false) then
-		Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c76794549.cfilter(c)


### PR DESCRIPTION
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=12906&request_locale=ja
the Group of cards to search includes any cards that was destroyed before during the turn Astrograph Sorcerer was summoned not just the cards destroyed at the triggering of Astrograph Sorcerer