### PR TITLE
Updated "Altergeist Protocol" dialogue box

### DIFF
--- a/script/c27541563.lua
+++ b/script/c27541563.lua
@@ -10,7 +10,7 @@ function c27541563.initial_effect(c)
 	c:RegisterEffect(e1)
 	--negate
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(27541563,1))
+	e2:SetDescription(aux.Stringid(27541563,0))
 	e2:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
 	e2:SetType(EFFECT_TYPE_ACTIVATE)
 	e2:SetCode(EVENT_CHAINING)


### PR DESCRIPTION
It was pointing to an incorrect strings (noticeable when you can activate it AND imediatlly apply its effect)