### PR TITLE
Fix banlist

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -537,7 +537,6 @@
 59297550 2 --Wind-up Magician
 10028593 2 --Reborn Tengu
 57103969 2 --Fire Formation - Tenki
-48976825 2 --Burial from a Different Dimension
 59750328 2 --Card of Demise
 73628505 2 --Terraforming
 66399653 2 --Union Hangar


### PR DESCRIPTION
Burial From a D.D. Limited in Worlds, not Semi

I removed the line, not edited, because it's in there twice.