### PR TITLE
Fixed cards to work with "Sanctuary of Parshath"

### DIFF
--- a/script/c100305002.lua
+++ b/script/c100305002.lua
@@ -28,10 +28,13 @@ function c100305002.atkop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc then return end
 	local cc=rc:GetCode()
 	local g=Duel.GetMatchingGroup(aux.NecroValleyFilter(c100305002.thfilter),tp,LOCATION_GRAVE,0,nil,cc)
-	if Duel.IsEnvironment(56433456) and g:GetCount()>0 then
+	if Duel.IsExistingMatchingCard(c100305002.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)) and g:GetCount()>0 then
 		Duel.Hint(HINT_CARD,0,100305002)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local sg=g:Select(tp,1,1,nil)
 		Duel.SendtoHand(sg,nil,REASON_EFFECT)
 	end
+end
+function c100305002.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
 end

--- a/script/c12171659.lua
+++ b/script/c12171659.lua
@@ -1,0 +1,46 @@
+--天空の使者 ゼラディアス
+function c12171659.initial_effect(c)
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(12171659,0))
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCost(c12171659.cost)
+	e1:SetTarget(c12171659.target)
+	e1:SetOperation(c12171659.operation)
+	c:RegisterEffect(e1)
+	--self destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EFFECT_SELF_DESTROY)
+	e2:SetCondition(c12171659.descon)
+	c:RegisterEffect(e2)
+end
+function c12171659.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToGraveAsCost() and c:IsDiscardable() end
+	Duel.SendtoGrave(c,REASON_COST+REASON_DISCARD)
+end
+function c12171659.filter(c)
+	return c:IsCode(56433456) and c:IsAbleToHand()
+end
+function c12171659.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.IsExistingMatchingCard(c12171659.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c12171659.operation(e,tp,eg,ep,ev,re,r,rp,chk)
+	local tg=Duel.GetFirstMatchingCard(c12171659.filter,tp,LOCATION_DECK,0,nil)
+	if tg then
+		Duel.SendtoHand(tg,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,tg)
+	end
+end
+function c12171659.descon(e)
+	return not (Duel.IsExistingMatchingCard(c12171659.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)))
+end
+function c12171659.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c12171659.lua
+++ b/script/c12171659.lua
@@ -39,8 +39,8 @@ function c12171659.operation(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function c12171659.descon(e)
-	return not (Duel.IsExistingMatchingCard(c12171659.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)))
+	return not (Duel.IsExistingMatchingCard(c12171659.sanctfilter,e:GetHandlerPlayer(),LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)))
 end
 function c12171659.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c12510878.lua
+++ b/script/c12510878.lua
@@ -1,0 +1,74 @@
+--天空勇士ネオパーシアス
+function c12510878.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c12510878.spcon)
+	e1:SetOperation(c12510878.spop)
+	c:RegisterEffect(e1)
+	--draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(12510878,0))
+	e2:SetCategory(CATEGORY_DRAW)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_BATTLE_DAMAGE)
+	e2:SetCondition(c12510878.condition)
+	e2:SetTarget(c12510878.target)
+	e2:SetOperation(c12510878.operation)
+	c:RegisterEffect(e2)
+	--pierce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_PIERCE)
+	c:RegisterEffect(e3)
+	--update atk,def
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(EFFECT_UPDATE_ATTACK)
+	e4:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetValue(c12510878.val)
+	c:RegisterEffect(e4)
+	local e5=e4:Clone()
+	e5:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e5)
+	--
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e6:SetCode(90162951)
+	c:RegisterEffect(e6)
+end
+function c12510878.spcon(e,c)
+	if c==nil then return true end
+	return Duel.CheckReleaseGroup(c:GetControler(),Card.IsCode,1,nil,18036057)
+end
+function c12510878.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectReleaseGroup(c:GetControler(),Card.IsCode,1,1,nil,18036057)
+	Duel.Release(g,REASON_COST)
+end
+function c12510878.condition(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp
+end
+function c12510878.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c12510878.operation(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end
+function c12510878.val(e,c)
+	if not (Duel.IsExistingMatchingCard(c12510878.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456))) then return 0 end
+	local v=Duel.GetLP(c:GetControler())-Duel.GetLP(1-c:GetControler())
+	if v>0 then return v else return 0 end
+end
+function c12510878.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c12510878.lua
+++ b/script/c12510878.lua
@@ -36,12 +36,6 @@ function c12510878.initial_effect(c)
 	local e5=e4:Clone()
 	e5:SetCode(EFFECT_UPDATE_DEFENSE)
 	c:RegisterEffect(e5)
-	--
-	local e6=Effect.CreateEffect(c)
-	e6:SetType(EFFECT_TYPE_SINGLE)
-	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e6:SetCode(90162951)
-	c:RegisterEffect(e6)
 end
 function c12510878.spcon(e,c)
 	if c==nil then return true end
@@ -70,5 +64,5 @@ function c12510878.val(e,c)
 	if v>0 then return v else return 0 end
 end
 function c12510878.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c18378582.lua
+++ b/script/c18378582.lua
@@ -1,0 +1,61 @@
+--大天使ゼラート
+function c18378582.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c18378582.spcon)
+	e2:SetOperation(c18378582.spop)
+	c:RegisterEffect(e2)
+	--destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(18378582,0))
+	e3:SetCategory(CATEGORY_DESTROY)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCost(c18378582.descost)
+	e3:SetTarget(c18378582.destg)
+	e3:SetOperation(c18378582.desop)
+	c:RegisterEffect(e3)
+end
+function c18378582.rfilter(c,code)
+	return c:IsFaceup() and c:IsCode(code)
+end
+function c18378582.spcon(e,c)
+	if c==nil then return Duel.IsExistingMatchingCard(c18378582.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)) end
+	return Duel.CheckReleaseGroup(c:GetControler(),c18378582.rfilter,1,nil,66073051)
+end
+function c18378582.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectReleaseGroup(tp,c18378582.rfilter,1,1,nil,66073051)
+	Duel.Release(g,REASON_COST)
+end
+function c18378582.cfilter(c)
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsDiscardable() and c:IsAbleToGraveAsCost()
+end
+function c18378582.descost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c18378582.cfilter,tp,LOCATION_HAND,0,1,nil) end
+	Duel.DiscardHand(tp,c18378582.cfilter,1,1,REASON_COST+REASON_DISCARD)
+end
+function c18378582.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c18378582.desop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsExistingMatchingCard(c18378582.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)) then
+		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_MZONE,nil)
+		Duel.Destroy(g,REASON_EFFECT)
+	end
+end
+function c18378582.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c18378582.lua
+++ b/script/c18378582.lua
@@ -57,5 +57,5 @@ function c18378582.desop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c18378582.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c28573958.lua
+++ b/script/c28573958.lua
@@ -85,5 +85,5 @@ function c28573958.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c28573958.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c28573958.lua
+++ b/script/c28573958.lua
@@ -1,0 +1,89 @@
+--奇跡の代行者 ジュピター
+function c28573958.initial_effect(c)
+	--atkup
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(28573958,0))
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetCountLimit(1)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCost(c28573958.atcost)
+	e1:SetTarget(c28573958.attg)
+	e1:SetOperation(c28573958.atop)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(28573958,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c28573958.spcon)
+	e2:SetCost(c28573958.spcost)
+	e2:SetTarget(c28573958.sptg)
+	e2:SetOperation(c28573958.spop)
+	c:RegisterEffect(e2)
+end
+function c28573958.cfilter1(c)
+	return c:IsSetCard(0x44) and c:IsAbleToRemoveAsCost()
+end
+function c28573958.atcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c28573958.cfilter1,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c28573958.cfilter1,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c28573958.filter1(c)
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY)
+end
+function c28573958.attg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c28573958.filter1(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c28573958.filter1,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c28573958.filter1,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c28573958.atop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(800)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+	end
+end
+function c28573958.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c28573958.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456))
+end
+function c28573958.cfilter2(c)
+	return c:IsRace(RACE_FAIRY) and c:IsDiscardable()
+end
+function c28573958.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c28573958.cfilter2,tp,LOCATION_HAND,0,1,nil) end
+	Duel.DiscardHand(tp,c28573958.cfilter2,1,1,REASON_COST+REASON_DISCARD)
+end
+function c28573958.filter2(c,e,tp)
+	return c:IsFaceup() and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c28573958.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_REMOVED) and chkc:IsControler(tp) and c28573958.filter2(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c28573958.filter2,tp,LOCATION_REMOVED,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c28573958.filter2,tp,LOCATION_REMOVED,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c28573958.spop(e,tp,eg,ep,ev,re,r,rp)
+	if not (Duel.IsExistingMatchingCard(c28573958.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456))) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c28573958.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c44595286.lua
+++ b/script/c44595286.lua
@@ -47,5 +47,5 @@ function c44595286.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c44595286.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c44595286.lua
+++ b/script/c44595286.lua
@@ -1,0 +1,51 @@
+--裁きの光
+function c44595286.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOGRAVE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetHintTiming(0,TIMING_TOHAND+0x1e0)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c44595286.condition)
+	e1:SetCost(c44595286.cost)
+	e1:SetTarget(c44595286.target)
+	e1:SetOperation(c44595286.activate)
+	c:RegisterEffect(e1)
+end
+function c44595286.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c44595286.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456))
+end
+function c44595286.cfilter(c)
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsDiscardable() and c:IsAbleToGraveAsCost()
+end
+function c44595286.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c44595286.cfilter,tp,LOCATION_HAND,0,1,nil) end
+	Duel.DiscardHand(tp,c44595286.cfilter,1,1,REASON_COST+REASON_DISCARD)
+end
+function c44595286.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_ONFIELD+LOCATION_HAND)>0 end
+end
+function c44595286.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g1=Duel.GetFieldGroup(tp,0,LOCATION_ONFIELD)
+	local g2=Duel.GetFieldGroup(tp,0,LOCATION_HAND)
+	local opt=0
+	if g1:GetCount()>0 and g2:GetCount()>0 then
+		opt=Duel.SelectOption(tp,aux.Stringid(44595286,0),aux.Stringid(44595286,1))+1
+	elseif g1:GetCount()>0 then opt=1
+	elseif g2:GetCount()>0 then opt=2
+	end
+	if opt==1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local g=g1:Select(tp,1,1,nil)
+		Duel.SendtoGrave(g,REASON_EFFECT)
+	elseif opt==2 then
+		Duel.ConfirmCards(tp,g2)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+		local g=g2:Select(tp,1,1,nil)
+		Duel.SendtoGrave(g,REASON_EFFECT)
+		Duel.ShuffleHand(1-tp)
+	end
+end
+function c44595286.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c48783998.lua
+++ b/script/c48783998.lua
@@ -1,0 +1,51 @@
+--コーリング・ノヴァ
+function c48783998.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(48783998,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_BATTLE_DESTROYED)
+	e1:SetCondition(c48783998.condition)
+	e1:SetTarget(c48783998.target)
+	e1:SetOperation(c48783998.operation)
+	c:RegisterEffect(e1)
+end
+function c48783998.condition(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
+end
+function c48783998.filter1(c,e,tp)
+	return c:IsAttackBelow(1500) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c48783998.filter2(c,e,tp)
+	return (c:IsCode(18036057) or (c:IsAttackBelow(1500) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY)))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c48783998.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return false end
+		if not (Duel.IsExistingMatchingCard(c48783998.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456))) then
+			return Duel.IsExistingMatchingCard(c48783998.filter1,tp,LOCATION_DECK,0,1,nil,e,tp)
+		else
+			return Duel.IsExistingMatchingCard(c48783998.filter2,tp,LOCATION_DECK,0,1,nil,e,tp)
+		end
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c48783998.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local g=nil
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	if not (Duel.IsExistingMatchingCard(c48783998.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456))) then
+		g=Duel.SelectMatchingCard(tp,c48783998.filter1,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	else
+		g=Duel.SelectMatchingCard(tp,c48783998.filter2,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	end
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c48783998.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c48783998.lua
+++ b/script/c48783998.lua
@@ -47,5 +47,5 @@ function c48783998.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c48783998.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c49905576.lua
+++ b/script/c49905576.lua
@@ -1,0 +1,22 @@
+--天空聖者メルティウス
+function c49905576.initial_effect(c)
+	--recover&destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_CHAIN_SOLVED)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetOperation(c49905576.drop)
+	c:RegisterEffect(e1)
+end
+function c49905576.drop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not re:GetHandler():IsType(TYPE_COUNTER) or not c:IsLocation(LOCATION_MZONE) or not c:IsFaceup() then return end
+	Duel.Recover(tp,1000,REASON_EFFECT)
+	if not Duel.IsExistingMatchingCard(c49905576.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)) then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectMatchingCard(tp,aux.TRUE,tp,0,LOCATION_ONFIELD,1,1,nil)
+	Duel.Destroy(g,REASON_EFFECT)
+end
+function c49905576.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c49905576.lua
+++ b/script/c49905576.lua
@@ -18,5 +18,5 @@ function c49905576.drop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Destroy(g,REASON_EFFECT)
 end
 function c49905576.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c55794644.lua
+++ b/script/c55794644.lua
@@ -73,5 +73,5 @@ function c55794644.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c55794644.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c55794644.lua
+++ b/script/c55794644.lua
@@ -1,0 +1,77 @@
+--マスター・ヒュペリオン
+function c55794644.initial_effect(c)
+	--spsummon proc
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c55794644.hspcon)
+	e1:SetOperation(c55794644.hspop)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(55794644,0))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c55794644.condition)
+	e2:SetCost(c55794644.cost)
+	e2:SetTarget(c55794644.target)
+	e2:SetOperation(c55794644.operation)
+	c:RegisterEffect(e2)
+end
+function c55794644.spfilter(c)
+	return c:IsSetCard(0x44) and c:IsAbleToRemoveAsCost() and (not c:IsLocation(LOCATION_MZONE) or c:IsFaceup())
+end
+function c55794644.hspcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if ft<=-1 then return false end
+	if ft<=0 then
+		return Duel.IsExistingMatchingCard(c55794644.spfilter,tp,LOCATION_MZONE,0,1,nil)
+	else return Duel.IsExistingMatchingCard(c55794644.spfilter,tp,0x16,0,1,nil) end
+end
+function c55794644.hspop(e,tp,eg,ep,ev,re,r,rp,c)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then
+		local g=Duel.SelectMatchingCard(tp,c55794644.spfilter,tp,LOCATION_MZONE,0,1,1,nil)
+		Duel.Remove(g,POS_FACEUP,REASON_COST)
+	else
+		local g=Duel.SelectMatchingCard(tp,c55794644.spfilter,tp,0x16,0,1,1,nil)
+		Duel.Remove(g,POS_FACEUP,REASON_COST)
+	end
+end
+function c55794644.condition(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsExistingMatchingCard(c55794644.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456))
+	then return e:GetHandler():GetFlagEffect(55794644)<2
+	else return e:GetHandler():GetFlagEffect(55794644)<1 end
+end
+function c55794644.costfilter(c)
+	return c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsRace(RACE_FAIRY) and c:IsAbleToRemoveAsCost()
+end
+function c55794644.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c55794644.costfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c55794644.costfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c55794644.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() end
+	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	e:GetHandler():RegisterFlagEffect(55794644,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c55794644.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end
+function c55794644.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c84177693.lua
+++ b/script/c84177693.lua
@@ -1,0 +1,31 @@
+--ホーリー・ジェラル
+function c84177693.initial_effect(c)
+	--recover
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(84177693,0))
+	e1:SetCategory(CATEGORY_RECOVER)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetCondition(c84177693.reccon)
+	e1:SetTarget(c84177693.rectg)
+	e1:SetOperation(c84177693.recop)
+	c:RegisterEffect(e1)
+end
+function c84177693.reccon(e,tp,eg,ep,ev,re,r,rp)
+	return not e:GetHandler():IsReason(REASON_BATTLE) and Duel.IsExistingMatchingCard(c84177693.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil)
+		or (Duel.IsEnvironment(56433456))
+end
+function c84177693.rectg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1000)
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,1000)
+end
+function c84177693.recop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Recover(p,d,REASON_EFFECT)
+end
+function c84177693.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c84177693.lua
+++ b/script/c84177693.lua
@@ -27,5 +27,5 @@ function c84177693.recop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Recover(p,d,REASON_EFFECT)
 end
 function c84177693.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c91123920.lua
+++ b/script/c91123920.lua
@@ -1,0 +1,40 @@
+--力の代行者 マーズ
+function c91123920.initial_effect(c)
+	--immune spell
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_IMMUNE_EFFECT)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetValue(c91123920.efilter)
+	c:RegisterEffect(e1)
+	--update atk,def
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetValue(c91123920.val)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e3)
+	--
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e5:SetCode(90162951)
+	c:RegisterEffect(e5)
+end
+function c91123920.efilter(e,te)
+	return te:IsActiveType(TYPE_SPELL)
+end
+function c91123920.val(e,c)
+	local tp=c:GetControler()
+	if not (Duel.IsExistingMatchingCard(c91123920.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or Duel.IsEnvironment(56433456)) then return 0 end
+	local v=Duel.GetLP(tp)-Duel.GetLP(1-tp)
+	if v>0 then return v else return 0 end
+end
+function c91123920.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c91188343.lua
+++ b/script/c91188343.lua
@@ -1,0 +1,40 @@
+--神秘の代行者 アース
+function c91188343.initial_effect(c)
+	--search
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(91188343,0))
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_SINGLE)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetTarget(c91188343.tg)
+	e1:SetOperation(c91188343.op)
+	c:RegisterEffect(e1)
+end
+function c91188343.filter1(c)
+	return c:IsSetCard(0x44) and c:GetCode()~=91188343 and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c91188343.filter2(c)
+	return ((c:IsSetCard(0x44) and c:GetCode()~=91188343 and c:IsType(TYPE_MONSTER)) or c:IsCode(55794644)) and c:IsAbleToHand()
+end
+function c91188343.tg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if not Duel.IsExistingMatchingCard(c91188343.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)) then
+			return Duel.IsExistingMatchingCard(c91188343.filter1,tp,LOCATION_DECK,0,1,nil) end
+		return Duel.IsExistingMatchingCard(c91188343.filter2,tp,LOCATION_DECK,0,1,nil)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c91188343.op(e,tp,eg,ep,ev,re,r,rp)
+	local g=nil
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	if not Duel.IsExistingMatchingCard(c91188343.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)) then
+		g=Duel.SelectMatchingCard(tp,c91188343.filter1,tp,LOCATION_DECK,0,1,1,nil)
+	else g=Duel.SelectMatchingCard(tp,c91188343.filter2,tp,LOCATION_DECK,0,1,1,nil) end
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c91188343.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c91188343.lua
+++ b/script/c91188343.lua
@@ -36,5 +36,5 @@ function c91188343.op(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c91188343.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c91345518.lua
+++ b/script/c91345518.lua
@@ -1,0 +1,41 @@
+--裁きの代行者 サターン
+function c91345518.initial_effect(c)
+	--damage
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(91345518,0))
+	e1:SetCategory(CATEGORY_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCost(c91345518.damcost)
+	e1:SetTarget(c91345518.damtg)
+	e1:SetOperation(c91345518.damop)
+	c:RegisterEffect(e1)
+end
+function c91345518.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetCurrentPhase()~=PHASE_MAIN2 and e:GetHandler():IsReleasable() end
+	Duel.Release(e:GetHandler(),REASON_COST)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e1:SetCode(EFFECT_CANNOT_BP)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	e1:SetTargetRange(1,0)
+	Duel.RegisterEffect(e1,tp)
+end
+function c91345518.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLP(tp)>Duel.GetLP(1-tp) end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+end
+function c91345518.damop(e,tp,eg,ep,ev,re,r,rp)
+	if not (Duel.IsExistingMatchingCard(c91345518.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or Duel.IsEnvironment(56433456)) then return end
+	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+	local val=Duel.GetLP(1-p)-Duel.GetLP(p)
+	if val>0 then
+		Duel.Damage(p,val,REASON_EFFECT)
+	end
+end
+function c91345518.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end

--- a/script/c91345518.lua
+++ b/script/c91345518.lua
@@ -37,5 +37,5 @@ function c91345518.damop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c91345518.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c97750534.lua
+++ b/script/c97750534.lua
@@ -20,7 +20,7 @@ function c97750534.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c97750534.spcon(e,c)
-	if c==nil then return Duel.IsExistingMatchingCard(c97750534.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)) end
+	if c==nil then return Duel.IsExistingMatchingCard(c97750534.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or Duel.IsEnvironment(56433456) end
 	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
 function c97750534.filter(c)
@@ -46,5 +46,5 @@ function c97750534.tgop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c97750534.sanctfilter(c)
-	return c:IsFaceup() and c:IsCode(22702055)
+	return c:IsFaceup() and c:IsCode(56433456)
 end

--- a/script/c97750534.lua
+++ b/script/c97750534.lua
@@ -1,0 +1,50 @@
+--死の代行者 ウラヌス
+function c97750534.initial_effect(c)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c97750534.spcon)
+	c:RegisterEffect(e1)
+	--tograve
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(97750534,0))
+	e2:SetCategory(CATEGORY_TOGRAVE)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetTarget(c97750534.tgtg)
+	e2:SetOperation(c97750534.tgop)
+	c:RegisterEffect(e2)
+end
+function c97750534.spcon(e,c)
+	if c==nil then return Duel.IsExistingMatchingCard(c97750534.sanctfilter,0,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) or (Duel.IsEnvironment(56433456)) end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+end
+function c97750534.filter(c)
+	return c:IsSetCard(0x44) and c:IsType(TYPE_MONSTER) and c:IsAbleToGrave()
+end
+function c97750534.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c97750534.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
+end
+function c97750534.tgop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c97750534.filter,tp,LOCATION_DECK,0,1,1,nil)
+	local tc=g:GetFirst()
+	if tc and Duel.SendtoGrave(tc,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_GRAVE) then
+		local lv=tc:GetLevel()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CHANGE_LEVEL)
+		e1:SetValue(lv)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
+		c:RegisterEffect(e1)
+	end
+end
+function c97750534.sanctfilter(c)
+	return c:IsFaceup() and c:IsCode(22702055)
+end


### PR DESCRIPTION
Fix list:
Angel Sage Minerva
Zeradias, Herald of Heaven
Neo-Parshath, the Sky Paladin
Archlord Zerato
The Agent of Miracles - Jupiter
Light of Judgement
Nova Summoner
Meltiel, Sage of the Sky
Master Hyperion
Radiant Jeral
The Agent of Mystery - Earth
The Agent of Entropy - Uranus
The Agent of Force - Mars
The Agent of Judgment - Saturn