### PR TITLE
Altar of Mind's Eye fix

### DIFF
--- a/script/c92481084.lua
+++ b/script/c92481084.lua
@@ -1,6 +1,4 @@
 --心眼の祭殿
---Altar of the Mind's Eye
---Script by nekrozar
 function c92481084.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -16,5 +14,12 @@ function c92481084.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c92481084.dop(e,tp,eg,ep,ev,re,r,rp)
+	local te=Duel.IsPlayerAffectedByEffect(ep,EFFECT_REVERSE_DAMAGE)
+	if te then
+		local val=te:GetValue()
+		if type(val)=='function' then
+			if val(e,re,r,rp,rc) then return end
+		else return end
+	end
 	Duel.ChangeBattleDamage(ep,1000)
 end


### PR DESCRIPTION
If affected by Rainbow Life (or similar cards), damage should not change to 1000