### PR TITLE
Fixed "Performapal Odd-Eyes Dissolver"

### DIFF
--- a/script/c46136942.lua
+++ b/script/c46136942.lua
@@ -60,6 +60,7 @@ function c46136942.pftg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c46136942.pfop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
 	local mg1=Duel.GetFusionMaterial(tp):Filter(c46136942.pffilter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c46136942.pffilter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)


### PR DESCRIPTION
No longer resolves the pendulum effect if leaves the field.