### PR TITLE
Cynet Backdoor ruling

### DIFF
--- a/script/c43839002.lua
+++ b/script/c43839002.lua
@@ -1,6 +1,4 @@
 --サイバネット・バックドア
---Cybnet Backdoor
---Scripted by Eerie Code
 function c43839002.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
@@ -8,17 +6,18 @@ function c43839002.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetHintTiming(0,TIMING_END_PHASE)
 	e1:SetCountLimit(1,43839002+EFFECT_COUNT_CODE_OATH)
 	e1:SetTarget(c43839002.target)
 	e1:SetOperation(c43839002.activate)
 	c:RegisterEffect(e1)
 end
 function c43839002.rmfilter(c,tp)
-	return c:IsFaceup() and c:IsRace(RACE_CYBERS) and c:IsAbleToRemove() and c:GetBaseAttack()>0
+	return c:IsFaceup() and c:IsRace(RACE_CYBERSE) and c:IsAbleToRemove() and c:GetBaseAttack()>0
 		and Duel.IsExistingMatchingCard(c43839002.thfilter,tp,LOCATION_DECK,0,1,nil,c)
 end
 function c43839002.thfilter(c,rc)
-	return c:IsRace(RACE_CYBERS) and c:GetAttack()<rc:GetBaseAttack() and c:IsAbleToHand()
+	return c:IsRace(RACE_CYBERSE) and c:GetAttack()<rc:GetBaseAttack() and c:IsAbleToHand()
 end
 function c43839002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c43839002.rmfilter(chkc,tp) end
@@ -30,7 +29,7 @@ function c43839002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c43839002.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT+REASON_TEMPORARY)>0 then
+	if tc and tc:IsRelateToEffect(e) and Duel.Remove(tc,tc:GetPosition(),REASON_EFFECT+REASON_TEMPORARY)>0 then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
@@ -40,6 +39,7 @@ function c43839002.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetCondition(c43839002.retcon)
 		e1:SetOperation(c43839002.retop)
 		Duel.RegisterEffect(e1,tp)
+		if tc:IsPreviousPosition(POS_FACEDOWN) then return end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local g=Duel.SelectMatchingCard(tp,c43839002.thfilter,tp,LOCATION_DECK,0,1,1,nil,tc)
 		if g:GetCount()>0 then
@@ -53,9 +53,11 @@ function c43839002.retcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c43839002.retop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=e:GetLabelObject()
-	if Duel.ReturnToField(tc) then
+	if tc and Duel.ReturnToField(tc) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetDescription(aux.Stringid(43839002,0))
+		e1:SetProperty(EFFECT_FLAG_CLIENT_HINT)
 		e1:SetCode(EFFECT_DIRECT_ATTACK)
 		e1:SetValue(1)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)

--- a/script/c43839002.lua
+++ b/script/c43839002.lua
@@ -1,4 +1,5 @@
 --サイバネット・バックドア
+---Cybnet Backdoor
 function c43839002.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
@@ -13,11 +14,11 @@ function c43839002.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c43839002.rmfilter(c,tp)
-	return c:IsFaceup() and c:IsRace(RACE_CYBERSE) and c:IsAbleToRemove() and c:GetBaseAttack()>0
+	return c:IsFaceup() and c:IsRace(RACE_CYBERS) and c:IsAbleToRemove() and c:GetBaseAttack()>0
 		and Duel.IsExistingMatchingCard(c43839002.thfilter,tp,LOCATION_DECK,0,1,nil,c)
 end
 function c43839002.thfilter(c,rc)
-	return c:IsRace(RACE_CYBERSE) and c:GetAttack()<rc:GetBaseAttack() and c:IsAbleToHand()
+	return c:IsRace(RACE_CYBERS) and c:GetAttack()<rc:GetBaseAttack() and c:IsAbleToHand()
 end
 function c43839002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c43839002.rmfilter(chkc,tp) end


### PR DESCRIPTION
If target is flipped face-down, it gets banished face-down and you don't add a Cyberse monster to hand, rest of the effects continue applying as is