### PR TITLE
Lost World fix

### DIFF
--- a/script/c17228908.lua
+++ b/script/c17228908.lua
@@ -1,6 +1,4 @@
 --ロストワールド
---Lost World
---Script by mercury233
 function c17228908.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -13,7 +11,7 @@ function c17228908.initial_effect(c)
 	e2:SetCode(EFFECT_UPDATE_ATTACK)
 	e2:SetRange(LOCATION_FZONE)
 	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
-	e2:SetTarget(c17228908.atktg)
+	e2:SetTarget(aux.NOT(aux.TargetBoolFunction(Card.IsRace,RACE_DINOSAUR)))
 	e2:SetValue(-500)
 	c:RegisterEffect(e2)
 	local e3=e2:Clone()
@@ -22,11 +20,11 @@ function c17228908.initial_effect(c)
 	--token
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(17228908,0))
-	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
 	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetProperty(EFFECT_FLAG_DELAY)
 	e4:SetCode(EVENT_SUMMON_SUCCESS)
 	e4:SetRange(LOCATION_FZONE)
-	e4:SetProperty(EFFECT_FLAG_DELAY)
 	e4:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
 	e4:SetCondition(c17228908.tkcon)
 	e4:SetTarget(c17228908.tktg)
@@ -60,9 +58,6 @@ function c17228908.initial_effect(c)
 	g:KeepAlive()
 	e7:SetLabelObject(g)
 end
-function c17228908.atktg(e,c)
-	return not c:IsRace(RACE_DINOSAUR)
-end
 function c17228908.cfilter(c,tp)
 	return c:IsFaceup() and c:IsRace(RACE_DINOSAUR)
 end
@@ -83,44 +78,44 @@ function c17228908.tkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c17228908.tgcon(e)
-	return Duel.IsExistingMatchingCard(Card.IsType,e:GetHandlerPlayer(),0,LOCATION_MZONE,1,nil,TYPE_TOKEN)
+	return Duel.IsExistingMatchingCard(Card.IsType,e:GetHandlerPlayer(),0,LOCATION_ONFIELD,1,nil,TYPE_TOKEN)
 end
 function c17228908.tglimit(e,c)
 	return not c:IsType(TYPE_TOKEN)
 end
-function c17228908.repfilter(c,tp,e)
-	return c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:IsLocation(LOCATION_MZONE)
+function c17228908.repfilter(c,tp)
+	return c:IsFaceup() and c:IsType(TYPE_NORMAL) and c:IsLocation(LOCATION_MZONE) and not c:IsReason(REASON_REPLACE)
 		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:GetFlagEffect(17228908)==0
 end
-function c17228908.desfilter(c,tp)
-	return c:IsRace(RACE_DINOSAUR) and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
+function c17228908.desfilter(c,e)
+	return c:IsRace(RACE_DINOSAUR) and c:IsDestructable(e)
+		and not c:IsStatus(STATUS_DESTROY_CONFIRMED+STATUS_BATTLE_DESTROYED)
 end
 function c17228908.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ct=eg:FilterCount(c17228908.repfilter,nil,tp,e)
+	local ct=eg:FilterCount(c17228908.repfilter,nil,tp)
 	if chk==0 then return ct>0
-		and Duel.IsExistingMatchingCard(c17228908.desfilter,tp,LOCATION_HAND+LOCATION_DECK,0,ct,nil,tp) end
-	if Duel.SelectYesNo(tp,aux.Stringid(17228908,1)) then
-		local g=eg:Filter(c17228908.repfilter,nil,tp,e)
+		and Duel.IsExistingMatchingCard(c17228908.desfilter,tp,LOCATION_HAND+LOCATION_DECK,0,ct,nil,e) end
+	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESREPLACE)
-		local tg=Duel.SelectMatchingCard(tp,c17228908.desfilter,tp,LOCATION_HAND+LOCATION_DECK,0,g:GetCount(),g:GetCount(),nil,tp)
-		Duel.SetTargetCard(tg)
+		local tg=Duel.SelectMatchingCard(tp,c17228908.desfilter,tp,LOCATION_HAND+LOCATION_DECK,0,ct,ct,nil,e)
+		local g=e:GetLabelObject()
+		g:Clear()
 		local tc=tg:GetFirst()
 		while tc do
 			tc:RegisterFlagEffect(17228908,RESET_EVENT+0x1fc0000+RESET_CHAIN,0,1)
 			tc:SetStatus(STATUS_DESTROY_CONFIRMED,true)
+			g:AddCard(tc)
 			tc=tg:GetNext()
 		end
-		e:GetLabelObject():Clear()
-		e:GetLabelObject():Merge(g)
 		return true
 	else return false end
 end
 function c17228908.repval(e,c)
-	local g=e:GetLabelObject()
-	return g:IsContains(c)
+	return c17228908.repfilter(c,e:GetHandlerPlayer())
 end
 function c17228908.repop(e,tp,eg,ep,ev,re,r,rp)
-	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	Duel.Hint(HINT_CARD,1-tp,17228908)
+	local tg=e:GetLabelObject()
 	local tc=tg:GetFirst()
 	while tc do
 		tc:SetStatus(STATUS_DESTROY_CONFIRMED,false)

--- a/script/c17228908.lua
+++ b/script/c17228908.lua
@@ -1,4 +1,5 @@
 --ロストワールド
+--Lost World
 function c17228908.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)


### PR DESCRIPTION
Target preventing applies if the Token isn't a monster (e.g. equipped via Relinquished)